### PR TITLE
refactor: simplify regex algebra and parser internals

### DIFF
--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -55,7 +55,14 @@ enum Regex:
   case Compl private[Regex] (r: Regex)
 
   /** Concatenation: `this · other`. */
-  infix def concat(other: Regex): Regex = Regex.concatImpl(this, other).result
+  infix def concat(other: Regex): Regex =
+    def loop(a: Regex, b: Regex): TailRec[Regex] = (a, b) match
+      case (Empty, _) | (_, Empty) => done(Empty)
+      case (Eps, x) => done(x)
+      case (x, Eps) => done(x)
+      case (Concat(x, y), z) => tailcall(loop(y, z)).map(Concat(x, _))
+      case _ => done(Concat(a, b))
+    loop(this, other).result
 
   /** Alternation: `this | other`. */
   infix def |(other: Regex): Regex = Regex.alt(Set(this, other))
@@ -108,11 +115,11 @@ object Regex:
     if flat.isEmpty then Empty
     else if flat.sizeIs == 1 then flat.head
     else
-      val (chars, rest) = flat.partition(_.isInstanceOf[Chars])
+      val (chars, rest) = flat.partitionIsInstance[Chars]
       val merged: Set[Regex] =
         if chars.sizeIs <= 1 then flat
         else
-          val union = chars.iterator.collect { case Chars(s) => s }.foldLeft(CharSet.empty)(_ union _)
+          val union = chars.iterator.map(_.set).foldLeft(CharSet.empty)(_ union _)
           if union.isEmpty then rest else rest + Chars(union)
       if merged.sizeIs == 1 then merged.head else Alt(merged)
 
@@ -125,23 +132,16 @@ object Regex:
       .toSet
     if seq.isEmpty || seq.contains(Empty) then Empty
     else
-      val (chars, rest) = seq.partition(_.isInstanceOf[Chars])
+      val (chars, rest) = seq.partitionIsInstance[Chars]
       val merged =
         if chars.sizeIs <= 1 then Some(seq)
         else
-          val isect = chars.iterator.collect { case Chars(s) => s }.reduce(_ intersect _)
+          val isect = chars.iterator.map(_.set).reduce(_ intersect _)
           Option.unless(isect.isEmpty)(rest + Chars(isect))
       merged match
         case None => Empty
         case Some(m) if m.sizeIs == 1 => m.head
         case Some(m) => Inter(m)
-
-  private def concatImpl(a: Regex, b: Regex): TailRec[Regex] = (a, b) match
-    case (Empty, _) | (_, Empty) => done(Empty)
-    case (Eps, x) => done(x)
-    case (x, Eps) => done(x)
-    case (Concat(x, y), z) => tailcall(concatImpl(y, z)).map(Concat(x, _))
-    case _ => done(Concat(a, b))
 
   /** All-strings regex `Σ*`. */
   val all: Regex = Regex(CharSet.all).star
@@ -271,3 +271,8 @@ private[regex] object Range:
     def apply(x: Range)(using Quotes): Expr[Range] =
       '{ Range(${ Expr(x.lo) }, ${ Expr(x.hi) }) }
   // $COVERAGE-ON$
+
+extension [A, CC[X] <: Iterable[X]](xs: scala.collection.IterableOps[A, CC, CC[A]])
+  inline private def partitionIsInstance[T <: A]: (CC[T], CC[A]) =
+    val (matches, rest) = xs.partition(_.isInstanceOf[T])
+    (matches.asInstanceOf[CC[T]], rest)

--- a/regex/RegexParser.scala
+++ b/regex/RegexParser.scala
@@ -2,7 +2,7 @@ package halotukozak.regex
 
 import halotukozak.regex.Regex.Eps
 
-import scala.annotation.tailrec
+import scala.annotation.{switch, tailrec}
 
 /** Reason a [[RegexParser.parse]] call did not produce a [[Regex]]. */
 sealed trait RegexParseError:
@@ -123,7 +123,7 @@ object RegexParser:
       @tailrec def loop(acc: Vector[Regex]): Vector[Regex] =
         if eof then acc
         else
-          cur match
+          (cur: @switch) match
             case ')' | '|' => acc
             case _ => loop(acc :+ parseFactor())
       val parts = loop(Vector.empty)
@@ -134,7 +134,7 @@ object RegexParser:
       val a = parseAtom()
       if eof then a
       else
-        cur match
+        (cur: @switch) match
           case '*' =>
             pos += 1
             a.star
@@ -153,7 +153,7 @@ object RegexParser:
       val lo = readNumber()
       if lo < 0 then fail(s"expected number after `{` at position $pos")
       if eof then fail(s"unterminated `{` at position $pos")
-      val hi = cur match
+      val hi = (cur: @switch) match
         case ',' =>
           pos += 1
           if !eof && cur == '}' then Int.MaxValue
@@ -183,7 +183,7 @@ object RegexParser:
     /** atom = group | charClass | `.` | escape | char */
     private def parseAtom(): Regex =
       if eof then fail("unexpected end of pattern")
-      cur match
+      (cur: @switch) match
         case '(' => parseGroup()
         case '[' => parseCharClass()
         case '.' =>
@@ -208,7 +208,7 @@ object RegexParser:
 
     private def consumeGroupHeader(): Unit =
       if eof then unsupported("incomplete group header")
-      cur match
+      (cur: @switch) match
         case ':' => pos += 1
         case '=' | '!' => unsupported("lookahead")
         case '<' =>
@@ -241,7 +241,7 @@ object RegexParser:
 
     private def readClassChar(): Int =
       if eof then fail("unterminated character class")
-      cur match
+      (cur: @switch) match
         case '\\' =>
           pos += 1
           readEscapedChar(inClass = true) match
@@ -252,7 +252,7 @@ object RegexParser:
     private def parseEscape(): Regex =
       expect('\\')
       if eof then fail("dangling backslash")
-      cur match
+      (cur: @switch) match
         case 'Q' =>
           pos += 1
           parseQuoted()
@@ -280,7 +280,7 @@ object RegexParser:
       if eof then fail("dangling backslash")
       val c = src.charAt(pos)
       pos += 1
-      c match
+      (c: @switch) match
         case 'd' => Left(CharSet.range('0', '9'))
         case 'D' => Left(CharSet.range('0', '9').complement)
         case 's' => Left(whitespaceSet)
@@ -294,8 +294,8 @@ object RegexParser:
         case 'a' => Right(0x07)
         case 'e' => Right(0x1b)
         case 'v' => Right(0x0b)
-        case 'b' if inClass => Right(0x08)
-        case 'b' | 'B' => unsupported(s"word boundary `\\$c`")
+        case 'b' => if inClass then Right(0x08) else unsupported(s"word boundary `\\$c`")
+        case 'B' => unsupported(s"word boundary `\\$c`")
         case 'A' | 'Z' | 'z' | 'G' => unsupported(s"anchor `\\$c`")
         case 'p' | 'P' => unsupported("Unicode property")
         case 'k' => unsupported("named backreference `\\k`")
@@ -305,9 +305,10 @@ object RegexParser:
         case 'x' => Right(readHexEscape())
         case 'u' => Right(readUnicodeEscape())
         case '0' => Right(readOctalEscape())
-        case d if d.isDigit => unsupported(s"backreference `\\$d`")
-        case l if l.isLetter => fail(s"illegal/unsupported escape sequence `\\$l` at position $pos")
-        case _ => Right(c.toInt)
+        case _ =>
+          if c.isDigit then unsupported(s"backreference `\\$c`")
+          else if c.isLetter then fail(s"illegal/unsupported escape sequence `\\$c` at position $pos")
+          else Right(c.toInt)
 
     /** `\cx`: control character `x XOR 0x40`. */
     private def readControlEscape(): Int =
@@ -324,29 +325,23 @@ object RegexParser:
         val text = src.substring(start, pos)
         pos += 1
         if text.isEmpty then fail("empty `\\x{}` escape")
-        val cp =
-          try Integer.parseInt(text, 16)
-          catch case _: NumberFormatException => fail(s"invalid hexadecimal escape sequence `\\x{$text}`")
+        val cp = text.toHexIntOpt.getOrElse(fail(s"invalid hexadecimal escape sequence `\\x{$text}`"))
         if cp < 0 || cp > CharSet.maxCodePoint then fail(s"invalid code point `\\x{$text}`")
         cp
       else
         if pos + 2 > src.length then fail("incomplete `\\x` escape")
         val text = src.substring(pos, pos + 2)
-        try
-          val v = Integer.parseInt(text, 16)
-          pos += 2
-          v
-        catch case _: NumberFormatException => fail(s"invalid hexadecimal escape sequence `\\x$text`")
+        val v = text.toHexIntOpt.getOrElse(fail(s"invalid hexadecimal escape sequence `\\x$text`"))
+        pos += 2
+        v
 
     /** `\uhhhh`: exactly 4 hex digits. */
     private def readUnicodeEscape(): Int =
       if pos + 4 > src.length then fail("incomplete `\\u` escape")
       val text = src.substring(pos, pos + 4)
-      try
-        val v = Integer.parseInt(text, 16)
-        pos += 4
-        v
-      catch case _: NumberFormatException => fail(s"invalid unicode escape sequence `\\u$text`")
+      val v = text.toHexIntOpt.getOrElse(fail(s"invalid unicode escape sequence `\\u$text`"))
+      pos += 4
+      v
 
     /** `\0n`, `\0nn` or `\0mnn` octal escape, mirroring `java.util.regex.Pattern`'s own grammar. */
     private def readOctalEscape(): Int =
@@ -360,3 +355,8 @@ object RegexParser:
           n * 64 + m * 8 + o
         else n * 8 + m
       else n
+
+extension (str: String)
+  private def toHexIntOpt: Option[Int] =
+    try Some(Integer.parseInt(str, 16))
+    catch case _: NumberFormatException => None


### PR DESCRIPTION
## Summary
- Merge `concatImpl` into `concat` as a local tail-recursive loop.
- Replace `partition(_.isInstanceOf[Chars])` + `collect` with a `partitionIsInstance` extension.
- `@switch` on the parser's character-dispatch matches.
- Fold the duplicated `\b`/`\B` and digit/letter escape cases together.
- Extract hex-digit parsing into a `toHexIntOpt` extension instead of repeating `try/catch Integer.parseInt` at each call site.

No behavior change. Pure internal cleanup.

## Test plan
- [x] `scala-cli test .` — all suites green (56+25+23+25+20 tests)
- [x] `scala-cli --power fmt --check .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)