### PR TITLE
perf: cache Regex#hashCode

### DIFF
--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -3,6 +3,7 @@ package halotukozak.regex
 import scala.annotation.{publicInBinary, tailrec}
 import scala.quoted.{Expr, Quotes, ToExpr, Varargs}
 import scala.util.control.TailCalls.{done, tailcall, TailRec}
+import scala.util.hashing.MurmurHash3
 
 /**
  * A symbolic regex algebra with exact language containment ("is this pattern a subset of
@@ -53,6 +54,14 @@ enum Regex:
 
   /** Complement `¬r`. */
   case Compl private[Regex] (r: Regex)
+
+  /**
+   * Cached: this tree is immutable and gets hashed repeatedly by the `Set`-based ACI
+   * normalization in `Regex.alt`/`Regex.inter` and by the visited-state set driving
+   * Brzozowski derivative exploration in [[Subset]] — recomputing structurally every time
+   * would walk the whole subtree on each lookup.
+   */
+  override lazy val hashCode: Int = MurmurHash3.caseClassHash(this)
 
   /** Concatenation: `this · other`. */
   infix def concat(other: Regex): Regex = Regex.concatImpl(this, other).result


### PR DESCRIPTION
## Summary
- `Regex` is an immutable enum, but the default case-class `hashCode` recomputes structurally (walking the whole subtree) on every call.
- That's hot for two paths: the `Set`-based ACI normalization in `alt`/`inter`, and the `visited: Set[Regex]` in `Subset.isEmptyImpl`, which drives the Brzozowski-derivative BFS that `subset`/`isEmpty` are built on — the core algorithm this library exists for.
- Scala 3 enum cases can't carry their own body (verified — `case Foo(x) extends Bar: ...` doesn't parse), so this overrides `hashCode` once at the enum level as a `lazy val`; each instance still gets its own cached copy since `lazy val` state is per-instance.

No behavior change (same structural hash/equals semantics, just memoized).

## Test plan
- [x] `scala-cli test .` — all suites green
- [x] `scala-cli --power fmt --check .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)