### PR TITLE
test: add JMH benchmarks and CI comparison against main

### DIFF
--- a/.github/scripts/compare_benchmarks.py
+++ b/.github/scripts/compare_benchmarks.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Renders a Markdown table comparing two JMH `-rf json` result files.
+
+Usage: compare_benchmarks.py <baseline.json> <candidate.json>
+"""
+
+import json
+import sys
+
+REGRESSION_THRESHOLD_PCT = 10.0
+
+
+def load(path: str) -> dict[str, dict]:
+    with open(path) as f:
+        entries = json.load(f)
+    return {e["benchmark"]: e for e in entries}
+
+
+def fmt_score(entry: dict) -> str:
+    metric = entry["primaryMetric"]
+    return f'{metric["score"]:.3f} {metric["scoreUnit"]}'
+
+
+def main() -> None:
+    baseline_path, candidate_path = sys.argv[1], sys.argv[2]
+    baseline = load(baseline_path)
+    candidate = load(candidate_path)
+    names = sorted(set(baseline) | set(candidate))
+
+    print("| Benchmark | main | current | Δ |")
+    print("|---|---|---|---|")
+    for name in names:
+        short_name = name.rsplit(".", 2)[-2] + "." + name.rsplit(".", 1)[-1]
+        base = baseline.get(name)
+        cand = candidate.get(name)
+        if base is None:
+            print(f"| `{short_name}` | — | {fmt_score(cand)} | 🆕 new |")
+            continue
+        if cand is None:
+            print(f"| `{short_name}` | {fmt_score(base)} | — | 🗑️ removed |")
+            continue
+
+        base_score = base["primaryMetric"]["score"]
+        cand_score = cand["primaryMetric"]["score"]
+        higher_is_better = base.get("mode") == "thrpt"
+        pct = (cand_score - base_score) / base_score * 100
+        signed_pct = pct if higher_is_better else -pct
+
+        if signed_pct <= -REGRESSION_THRESHOLD_PCT:
+            marker = "🔴"
+        elif signed_pct >= REGRESSION_THRESHOLD_PCT:
+            marker = "🟢"
+        else:
+            marker = "⚪"
+
+        print(f"| `{short_name}` | {fmt_score(base)} | {fmt_score(cand)} | {marker} {pct:+.1f}% |")
+
+    print()
+    print(
+        f"Δ is candidate vs. `main`; positive means the metric's value grew "
+        f"(slower for time-based benchmarks, faster for throughput ones). "
+        f"🔴/🟢 mark a ≥{REGRESSION_THRESHOLD_PCT:.0f}% regression/improvement — "
+        f"informational only, single-sample on a shared runner, not a merge gate."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,11 @@ jobs:
       - uses: VirtusLab/scala-cli-setup@v1
       - name: Run tests
         # Coverage is recorded only for production sources; tests were previously
-        # measured as 100%-covered and inflated the reported number.
-        run: scala-cli --power test . -O -coverage-out:./.scoverage -O '-coverage-exclude-files:.*test/.*'
+        # measured as 100%-covered and inflated the reported number. bench/ is excluded
+        # because it only compiles under `--jmh` (see the benchmark job below).
+        run: >
+          scala-cli --power test . --exclude "bench/**"
+          -O -coverage-out:./.scoverage -O '-coverage-exclude-files:.*test/.*'
       - name: Generate coverage
         run: scala-cli .scoverage/report.sc
       - uses: codecov/codecov-action@v7
@@ -40,7 +43,7 @@ jobs:
           files: .scoverage/report/cobertura.xml
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Test documentation
-        run: scala-cli --power doc .
+        run: scala-cli --power doc . --exclude "bench/**"
 
   compile:
     name: Compile (${{ matrix.platform }})
@@ -61,7 +64,7 @@ jobs:
         uses: coursier/cache-action@v8.1
       - uses: VirtusLab/scala-cli-setup@v1
       - name: Compile
-        run: scala-cli --power compile . --platform ${{ matrix.platform }} ${{ matrix.args }}
+        run: scala-cli --power compile . --exclude "bench/**" --platform ${{ matrix.platform }} ${{ matrix.args }}
 
   # JVM is covered by the `test` job above (with coverage/docs); this just runs
   # the same suite on the other targets to catch platform-specific regressions.
@@ -82,4 +85,37 @@ jobs:
         uses: coursier/cache-action@v8.1
       - uses: VirtusLab/scala-cli-setup@v1
       - name: Run tests
-        run: scala-cli --power test . --platform ${{ matrix.platform }} ${{ matrix.args }}
+        run: scala-cli --power test . --exclude "bench/**" --platform ${{ matrix.platform }} ${{ matrix.args }}
+
+  # Runs the JMH suite in bench/ against both the PR branch and main, on the same runner
+  # back-to-back, then diffs the two result sets. Informational only (see the note the
+  # compare script prints) — a shared CI runner is too noisy to gate merges on.
+  benchmark:
+    name: Benchmark (current vs main)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Setup coursier cache
+        uses: coursier/cache-action@v8.1
+      - uses: VirtusLab/scala-cli-setup@v1
+      - name: Run benchmarks on current branch
+        run: >
+          scala-cli run --jmh . --exclude "test/**" --
+          -f 1 -wi 3 -i 5 -w 300ms -r 300ms -rf json -rff "$GITHUB_WORKSPACE/current-bench.json"
+      - name: Run benchmarks on main
+        # Reuses the PR's bench/ harness (and project.scala, for identical compiler
+        # settings) against main's library sources, so only regex/ actually differs.
+        run: |
+          git worktree add /tmp/main-baseline origin/main
+          rm -rf /tmp/main-baseline/bench
+          cp -r bench /tmp/main-baseline/bench
+          cp project.scala /tmp/main-baseline/project.scala
+          cd /tmp/main-baseline
+          scala-cli run --jmh . --exclude "test/**" -- \
+            -f 1 -wi 3 -i 5 -w 300ms -r 300ms -rf json -rff "$GITHUB_WORKSPACE/main-bench.json"
+      - name: Compare
+        run: |
+          python3 .github/scripts/compare_benchmarks.py main-bench.json current-bench.json | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: VirtusLab/scala-cli-setup@v1
       - name: Run benchmarks on current branch
         run: >
-          scala-cli run --jmh . --exclude "test/**" --
+          scala-cli --power run --jmh . --exclude "test/**" --
           -f 1 -wi 3 -i 5 -w 300ms -r 300ms -rf json -rff "$GITHUB_WORKSPACE/current-bench.json"
       - name: Run benchmarks on main
         # Reuses the PR's bench/ harness (and project.scala, for identical compiler
@@ -114,7 +114,7 @@ jobs:
           cp -r bench /tmp/main-baseline/bench
           cp project.scala /tmp/main-baseline/project.scala
           cd /tmp/main-baseline
-          scala-cli run --jmh . --exclude "test/**" -- \
+          scala-cli --power run --jmh . --exclude "test/**" -- \
             -f 1 -wi 3 -i 5 -w 300ms -r 300ms -rf json -rff "$GITHUB_WORKSPACE/main-bench.json"
       - name: Compare
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
     name: Benchmark (current vs main)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -118,4 +120,9 @@ jobs:
             -f 1 -wi 3 -i 5 -w 300ms -r 300ms -rf json -rff "$GITHUB_WORKSPACE/main-bench.json"
       - name: Compare
         run: |
-          python3 .github/scripts/compare_benchmarks.py main-bench.json current-bench.json | tee -a "$GITHUB_STEP_SUMMARY"
+          python3 .github/scripts/compare_benchmarks.py main-bench.json current-bench.json | tee comparison.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Comment on PR
+        uses: marocchino/sticky-pull-request-comment@v3.0.5
+        with:
+          header: benchmark
+          path: comparison.md

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: VirtusLab/scala-cli-setup@v1
       - name: Generate documentation
         run: |
-          scala-cli --power doc . -- \
+          scala-cli --power doc . --exclude "bench/**" -- \
           -project "regex" \
           -project-version ${{ github.ref_name }} \
           -project-footer "halotukozak/regex" \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
           PGP_PRIVATE_KEY: ${{ secrets.PGP_PRIVATE_KEY }}
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         run: |
-          scala-cli --power publish . --verbose --platform ${{ matrix.platform }} ${{ matrix.args }} \
+          scala-cli --power publish . --exclude "bench/**" --verbose --platform ${{ matrix.platform }} ${{ matrix.args }} \
             --user "env:SONATYPE_USERNAME" \
             --password "env:SONATYPE_PASSWORD" \
             --secret-key "env:PGP_PRIVATE_KEY" \
@@ -63,12 +63,12 @@ jobs:
           set -euo pipefail
 
           # 1. Reusable javadoc from JVM scaladoc (platform-agnostic API; JS scaladoc is broken).
-          scala-cli --power publish . --platform jvm --signer none \
+          scala-cli --power publish . --exclude "bench/**" --platform jvm --signer none \
             --publish-repository "$PWD/.jvmdoc"
           jdoc="$(find "$PWD/.jvmdoc" -name 'regex_3-*-javadoc.jar' | head -1)"
 
           # 2. JS artifacts (jar/sources/pom + checksums), unsigned and without a doc JAR.
-          scala-cli --power publish . --platform scala-js --js-version 1.22.0 \
+          scala-cli --power publish . --exclude "bench/**" --platform scala-js --js-version 1.22.0 \
             --doc=false --signer none --publish-repository "$PWD/.staging"
 
           # 3. Inject the reused javadoc into the regex_sjs1_3 coordinate.

--- a/bench/CharSetBenchmark.scala
+++ b/bench/CharSetBenchmark.scala
@@ -3,11 +3,12 @@ package halotukozak.regex
 import org.openjdk.jmh.annotations.*
 
 import java.util.concurrent.TimeUnit
+import scala.compiletime.uninitialized
 
 /**
- * `CharSet.contains` currently does a linear scan over sorted, non-overlapping ranges —
- * a candidate for a binary search. This benchmark isolates that operation with many
- * disjoint ranges so the two strategies are actually distinguishable.
+ * `CharSet.contains` currently does a linear scan over sorted, non-overlapping ranges — a
+ * candidate for a binary search. `rangeCount` lets that (and the other set operations) be
+ * measured across input sizes instead of at one fixed point.
  *
  * Run: `scala-cli run --jmh . -- CharSetBenchmark` (see `bench/README.md`).
  */
@@ -16,16 +17,41 @@ import java.util.concurrent.TimeUnit
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 class CharSetBenchmark:
 
-  private val manyRanges: CharSet = CharSet.normalize((0 until 2000).map(i => Range(i * 4, i * 4 + 1)))
+  @Param(Array("50", "500", "5000"))
+  var rangeCount: Int = uninitialized
+
+  private var ranges: CharSet = uninitialized
+  private var interleaved: CharSet = uninitialized
+  private var reversedRanges: Vector[Range] = uninitialized
+
+  @Setup(Level.Trial)
+  def setup(): Unit =
+    ranges = CharSet.normalize((0 until rangeCount).map(i => Range(i * 4, i * 4 + 1)))
+    // Every other gap, so union/intersect actually have interleaving work to do.
+    interleaved = CharSet.normalize((0 until rangeCount).map(i => Range(i * 4 + 2, i * 4 + 3)))
+    reversedRanges = (0 until rangeCount).map(i => Range(i * 4, i * 4 + 1)).reverse.toVector
 
   /** Worst case for a linear scan: the match is the very last range. */
   @Benchmark
-  def containsNearEnd(): Boolean = manyRanges.contains(manyRanges.ranges.last.lo)
+  def containsNearEnd(): Boolean = ranges.contains(ranges.ranges.last.lo)
 
   /** Best case for a linear scan: the match is the very first range. */
   @Benchmark
-  def containsNearStart(): Boolean = manyRanges.contains(0)
+  def containsNearStart(): Boolean = ranges.contains(0)
 
   /** A miss (falls in a gap), which still has to prove absence across the whole set. */
   @Benchmark
-  def containsMiss(): Boolean = manyRanges.contains(manyRanges.ranges.last.lo + 2)
+  def containsMiss(): Boolean = ranges.contains(ranges.ranges.last.lo + 2)
+
+  @Benchmark
+  def union(): CharSet = ranges.union(interleaved)
+
+  @Benchmark
+  def intersect(): CharSet = ranges.intersect(interleaved)
+
+  @Benchmark
+  def complement(): CharSet = ranges.complement
+
+  /** Sort-and-merge from scratch, worst-case (fully reversed) input order. */
+  @Benchmark
+  def normalize(): CharSet = CharSet.normalize(reversedRanges)

--- a/bench/CharSetBenchmark.scala
+++ b/bench/CharSetBenchmark.scala
@@ -1,0 +1,31 @@
+package halotukozak.regex
+
+import org.openjdk.jmh.annotations.*
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * `CharSet.contains` currently does a linear scan over sorted, non-overlapping ranges —
+ * a candidate for a binary search. This benchmark isolates that operation with many
+ * disjoint ranges so the two strategies are actually distinguishable.
+ *
+ * Run: `scala-cli run --jmh . -- CharSetBenchmark` (see `bench/README.md`).
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+class CharSetBenchmark:
+
+  private val manyRanges: CharSet = CharSet.normalize((0 until 2000).map(i => Range(i * 4, i * 4 + 1)))
+
+  /** Worst case for a linear scan: the match is the very last range. */
+  @Benchmark
+  def containsNearEnd(): Boolean = manyRanges.contains(manyRanges.ranges.last.lo)
+
+  /** Best case for a linear scan: the match is the very first range. */
+  @Benchmark
+  def containsNearStart(): Boolean = manyRanges.contains(0)
+
+  /** A miss (falls in a gap), which still has to prove absence across the whole set. */
+  @Benchmark
+  def containsMiss(): Boolean = manyRanges.contains(manyRanges.ranges.last.lo + 2)

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,26 @@
+# Benchmarks
+
+JMH microbenchmarks for the hot paths of this library: `Regex` construction (`alt`/`concat`/
+`repeat`, which drive `Set`-based ACI normalization and `hashCode`), the Brzozowski-derivative
+machinery in `Subset` (`subset`/`isEmpty`/`derive`), and `CharSet.contains`.
+
+This directory only compiles under `--jmh` — it's excluded (`--exclude "bench/**"`) from every
+other `scala-cli` invocation (`compile`, `test`, `doc`, `publish`) because `@Benchmark` needs
+`jmh-core` on the classpath, which `--jmh` injects automatically.
+
+## Running locally
+
+```sh
+# everything
+scala-cli run --jmh . --exclude "test/**"
+
+# one class, faster iteration while developing a benchmark
+scala-cli run --jmh . --exclude "test/**" -- SubsetBenchmark -f 1 -wi 2 -i 2 -w 300ms -r 300ms
+```
+
+## CI
+
+On every PR, the `benchmark` job in `.github/workflows/ci.yml` runs this suite against the PR
+branch and against `main` (same `bench/` harness both times, via a `git worktree`, so only
+`regex/` differs) and posts a comparison table to the job summary. It's informational only — a
+shared GitHub-hosted runner is too noisy for single-sample numbers to gate a merge on.

--- a/bench/RegexBenchmark.scala
+++ b/bench/RegexBenchmark.scala
@@ -1,0 +1,29 @@
+package halotukozak.regex
+
+import org.openjdk.jmh.annotations.*
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Construction-side benchmarks: smart-constructor normalization (`alt`/`concat`/`repeat`,
+ * which drive `Set`-based ACI dedup and therefore `Regex#hashCode`) and parsing.
+ *
+ * Run: `scala-cli run --jmh . -- RegexBenchmark` (see `bench/README.md`).
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+class RegexBenchmark:
+
+  private val pattern = """(foo|bar|baz|qux){2,10}[a-zA-Z0-9_]+\d{3,5}(\.[a-z]{2,4})?"""
+
+  /** Builds a 50-way alternation of distinct literals, one `|` at a time. */
+  @Benchmark
+  def buildAlternation(): Regex = (0 until 50).foldLeft(Regex.Empty: Regex)((acc, i) => acc | Regex.literal(s"token$i"))
+
+  /** Unfolds a bounded quantifier into its `Concat`/`Alt` expansion. */
+  @Benchmark
+  def repeatBounded(): Regex = Regex.lit('a').repeat(0, 500)
+
+  @Benchmark
+  def parse(): Regex = RegexParser.parse(pattern).toOption.get

--- a/bench/RegexBenchmark.scala
+++ b/bench/RegexBenchmark.scala
@@ -3,10 +3,12 @@ package halotukozak.regex
 import org.openjdk.jmh.annotations.*
 
 import java.util.concurrent.TimeUnit
+import scala.compiletime.uninitialized
 
 /**
- * Construction-side benchmarks: smart-constructor normalization (`alt`/`concat`/`repeat`,
- * which drive `Set`-based ACI dedup and therefore `Regex#hashCode`) and parsing.
+ * Construction-side benchmarks: smart-constructor normalization (`alt`/`inter`/`concat`/
+ * `repeat`, which drive `Set`-based ACI dedup and therefore `Regex#hashCode`) and parsing.
+ * `branches` scales the alternation/intersection benchmarks across input sizes.
  *
  * Run: `scala-cli run --jmh . -- RegexBenchmark` (see `bench/README.md`).
  */
@@ -15,11 +17,22 @@ import java.util.concurrent.TimeUnit
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 class RegexBenchmark:
 
+  @Param(Array("10", "50", "200"))
+  var branches: Int = uninitialized
+
   private val pattern = """(foo|bar|baz|qux){2,10}[a-zA-Z0-9_]+\d{3,5}(\.[a-z]{2,4})?"""
 
-  /** Builds a 50-way alternation of distinct literals, one `|` at a time. */
+  /** Builds a `branches`-way alternation of distinct literals, one `|` at a time. */
   @Benchmark
-  def buildAlternation(): Regex = (0 until 50).foldLeft(Regex.Empty: Regex)((acc, i) => acc | Regex.literal(s"token$i"))
+  def buildAlternation(): Regex = (0 until branches).foldLeft(Regex.Empty: Regex)((acc, i) =>
+    acc | Regex.literal(s"token$i"),
+  )
+
+  /** Builds a `branches`-way intersection of char-range regexes (the `Chars`-merge path in `inter`). */
+  @Benchmark
+  def buildIntersection(): Regex = (0 until branches).foldLeft(Regex(CharSet.all): Regex)((acc, i) =>
+    acc & Regex.range('a', ('a' + i % 26).toChar),
+  )
 
   /** Unfolds a bounded quantifier into its `Concat`/`Alt` expansion. */
   @Benchmark

--- a/bench/SubsetBenchmark.scala
+++ b/bench/SubsetBenchmark.scala
@@ -18,11 +18,32 @@ class SubsetBenchmark:
   private val narrow = Subset.parse("""[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.(com|org|net|io)""").toOption.get
   private val wide = Subset.parse(""".*@.*\..*""").toOption.get
 
+  // Shares a long common prefix with `narrow` but drops the `io` alternative, so `subset`
+  // has to derive deep before it can tell the two languages apart — a true-negative case,
+  // as opposed to `wide` above which is an obvious (and cheap-to-confirm) superset.
+  private val almostWide = Subset.parse("""[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.(com|org|net)""").toOption.get
+
+  // A string can't end in both 'b' and 'c', so this intersection's language is empty — but
+  // unlike e.g. `[a-z]+ & [A-Z]+`, the smart constructors can't see that at construction
+  // time (neither operand is a bare `Chars` node, so the CharSet-merge fast path in `inter`
+  // never fires). Proving it empty needs the real thing: isEmptyImpl's BFS has to explore
+  // derivatives across the whole `[a-z]*` middle section before it can conclude there's no
+  // reachable accepting state.
+  private val disjointIntersection = Subset.of(
+    Subset.parse("a[a-z]*b").toOption.get.underlying & Subset.parse("a[a-z]*c").toOption.get.underlying,
+  )
+
   @Benchmark
   def subsetCheck(): Boolean = narrow.subset(wide)
 
   @Benchmark
+  def subsetCheckNegative(): Boolean = narrow.subset(almostWide)
+
+  @Benchmark
   def isEmptyCheck(): Boolean = narrow.isEmpty
+
+  @Benchmark
+  def isEmptyCheckWorstCase(): Boolean = disjointIntersection.isEmpty
 
   @Benchmark
   def deriveChain(): Boolean =

--- a/bench/SubsetBenchmark.scala
+++ b/bench/SubsetBenchmark.scala
@@ -1,0 +1,29 @@
+package halotukozak.regex
+
+import org.openjdk.jmh.annotations.*
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Benchmarks for the Brzozowski-derivative machinery in [[Subset]] — the core algorithm
+ * this library exists for (`subset`/`isEmpty` drive the exact language-containment check).
+ *
+ * Run: `scala-cli run --jmh . -- SubsetBenchmark` (see `bench/README.md`).
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+class SubsetBenchmark:
+
+  private val narrow = Subset.parse("""[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.(com|org|net|io)""").toOption.get
+  private val wide = Subset.parse(""".*@.*\..*""").toOption.get
+
+  @Benchmark
+  def subsetCheck(): Boolean = narrow.subset(wide)
+
+  @Benchmark
+  def isEmptyCheck(): Boolean = narrow.isEmpty
+
+  @Benchmark
+  def deriveChain(): Boolean =
+    "user@example.com".foldLeft(narrow)((s, c) => s.derive(c.toInt)).nullable


### PR DESCRIPTION
## Summary
- New `bench/` directory: JMH microbenchmarks for the library's hot paths — `Regex` construction (`alt`/`concat`/`repeat`), the Brzozowski-derivative machinery in `Subset` (`subset`/`isEmpty`/`derive`), and `CharSet.contains`.
- `bench/` only compiles under `--jmh` (needs `jmh-core`, which the flag injects automatically — confirmed no manual dependency declaration needed). It's excluded via `--exclude "bench/**"` from every other `scala-cli` invocation across `ci.yml`, `docs.yaml`, and `publish.yml` so the normal build/test/doc/publish path stays untouched.
- New `benchmark` job in `ci.yml`, gated on `pull_request`: runs the suite against the PR branch and against `main` on the same runner back-to-back (main checked out via `git worktree`, with the PR's `bench/` harness copied over so only `regex/` actually differs between the two runs), then renders a comparison table via `.github/scripts/compare_benchmarks.py` into the job summary.
- Comparison is informational only, not a merge gate — a shared GitHub-hosted runner is too noisy for single-sample JMH numbers to fail a build on.

## Test plan
- [x] `scala-cli test . --exclude "bench/**"` — all suites green, bench correctly excluded
- [x] `scala-cli compile --jmh . --exclude "test/**"` — bench compiles and JMH picks up all classes
- [x] `scala-cli run --jmh .` end-to-end locally (all 3 benchmark classes ran, produced JSON output)
- [x] `scala-cli --power fmt --check .`
- [x] YAML syntax validated for all 3 touched workflow files
- [ ] Actual CI run of the new `benchmark` job (can only be verified once this PR is open against `origin/main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)