### PR TITLE
fix: disambiguate @Param'd benchmarks in compare_benchmarks.py

### DIFF
--- a/.github/scripts/compare_benchmarks.py
+++ b/.github/scripts/compare_benchmarks.py
@@ -10,10 +10,20 @@ import sys
 REGRESSION_THRESHOLD_PCT = 10.0
 
 
+def bench_key(entry: dict) -> str:
+    """Disambiguates @Param'd benchmarks — JMH gives every param combination the same
+    `benchmark` name, so keying on that alone silently collapses them onto each other."""
+    params = entry.get("params") or {}
+    if not params:
+        return entry["benchmark"]
+    param_str = ",".join(f"{k}={v}" for k, v in sorted(params.items()))
+    return f'{entry["benchmark"]}[{param_str}]'
+
+
 def load(path: str) -> dict[str, dict]:
     with open(path) as f:
         entries = json.load(f)
-    return {e["benchmark"]: e for e in entries}
+    return {bench_key(e): e for e in entries}
 
 
 def fmt_score(entry: dict) -> str:
@@ -30,7 +40,10 @@ def main() -> None:
     print("| Benchmark | main | current | Δ |")
     print("|---|---|---|---|")
     for name in names:
-        short_name = name.rsplit(".", 2)[-2] + "." + name.rsplit(".", 1)[-1]
+        method, _, params = name.partition("[")
+        short_name = method.rsplit(".", 2)[-2] + "." + method.rsplit(".", 1)[-1]
+        if params:
+            short_name += "[" + params
         base = baseline.get(name)
         cand = candidate.get(name)
         if base is None:


### PR DESCRIPTION
## Summary
- JMH gives every `@Param` combination of a benchmark the same `benchmark` field in its JSON output — they only differ in `params`. Keying the comparison dict on `benchmark` alone silently collapsed all param combinations onto whichever one loaded last (in practice, the last one in the JSON array).
- Concretely: `CharSetBenchmark`'s `rangeCount=50/500/5000` variants and `RegexBenchmark`'s `branches=10/50/200` variants were being compared as if each method were a single benchmark — two of every three data points were silently dropped.
- Fold `params` into the comparison key and show them in the rendered benchmark name (e.g. `containsMiss[rangeCount=5000]`).

Caught this while locally validating #6 (`CharSet.contains` binary search) — the comparison table only showed the `rangeCount=5000` numbers until this fix.

## Test plan
- [x] Re-ran the script against the same two JSON files from #6's local validation — now shows all 3 `rangeCount`/`branches` variants per parameterized benchmark instead of 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)