### PR TITLE
perf: use Queue instead of List for isEmptyImpl's BFS frontier

### DIFF
--- a/bench/SubsetBenchmark.scala
+++ b/bench/SubsetBenchmark.scala
@@ -33,6 +33,16 @@ class SubsetBenchmark:
     Subset.parse("a[a-z]*b").toOption.get.underlying & Subset.parse("a[a-z]*c").toOption.get.underlying,
   )
 
+  // Same idea as disjointIntersection but with a much wider reachable-state set: a 100-way
+  // alternation of distinct fixed-length tokens (which alone builds a sizeable prefix-trie
+  // of derivative states) intersected with a literal that matches none of them. Neither
+  // operand is a bare Chars node, so the smart constructors can't collapse this to Empty at
+  // construction time — isEmptyImpl's BFS has to walk the whole state space. Meant to stress
+  // the BFS queue itself at a size where an O(n) vs O(n^2) difference would actually show up.
+  private val manyStatesEmpty = Subset.of(
+    Regex.inter(Set(Regex.alt((0 until 100).map(i => Regex.literal(f"token$i%03d"))), Regex.literal("nomatch"))),
+  )
+
   @Benchmark
   def subsetCheck(): Boolean = narrow.subset(wide)
 
@@ -44,6 +54,9 @@ class SubsetBenchmark:
 
   @Benchmark
   def isEmptyCheckWorstCase(): Boolean = disjointIntersection.isEmpty
+
+  @Benchmark
+  def isEmptyCheckManyStates(): Boolean = manyStatesEmpty.isEmpty
 
   @Benchmark
   def deriveChain(): Boolean =

--- a/regex/Subset.scala
+++ b/regex/Subset.scala
@@ -2,7 +2,7 @@ package halotukozak.regex
 
 import halotukozak.regex.Regex.*
 
-import scala.collection.immutable.SortedSet
+import scala.collection.immutable.{Queue, SortedSet}
 import scala.util.control.TailCalls.{done, tailcall, TailRec}
 
 /**
@@ -49,21 +49,22 @@ object Subset:
     def derive(c: Int): Subset = deriveImpl(a, c).result
 
   private def isEmptyImpl(r: Regex): Boolean =
-    def loop(queue: List[Regex], visited: Set[Regex]): TailRec[Boolean] = queue match
-      case Nil => done(true)
-      case s :: rest =>
-        for
-          isNull <- tailcall(nullableImpl(s))
-          out <-
-            if isNull then done(false)
-            else
-              for
-                derived <- tailcall(deriveAt(partitionReps(s), s, Nil))
-                next = derived.filterNot(visited.contains)
-                r <- tailcall(loop(rest ::: next, visited ++ next))
-              yield r
-        yield out
-    loop(List(r), Set(r)).result
+    def loop(queue: Queue[Regex], visited: Set[Regex]): TailRec[Boolean] =
+      queue.dequeueOption match
+        case None => done(true)
+        case Some((s, rest)) =>
+          for
+            isNull <- tailcall(nullableImpl(s))
+            out <-
+              if isNull then done(false)
+              else
+                for
+                  derived <- tailcall(deriveAt(partitionReps(s), s, Nil))
+                  next = derived.filterNot(visited.contains)
+                  r <- tailcall(loop(rest.enqueueAll(next), visited ++ next))
+                yield r
+          yield out
+    loop(Queue(r), Set(r)).result
 
   private def nullableImpl(r: Regex): TailRec[Boolean] = r match
     case Eps => done(true)


### PR DESCRIPTION
## Summary
- `isEmptyImpl`'s BFS frontier was a `List[Regex]`, advanced via `rest ::: next` — that copies the whole remaining queue on every step, so it's O(n) per step and up to O(n²) total over a BFS exploring n reachable derivative states.
- Swapped to `scala.collection.immutable.Queue`, which gives O(1) amortized enqueue/dequeue instead.
- No functional change — `SubsetTest` (emptiness/subset semantics) is unaffected, this only changes how the frontier is stored.

## Benchmarks — honest result
Added `isEmptyCheckManyStates` to `bench/SubsetBenchmark`: a 100-way alternation of distinct fixed-length tokens intersected with a literal that matches none of them (neither operand is a bare `Chars` node, so the smart constructors can't collapse it to `Empty` at construction time — forces a real BFS).

Compared locally against `main`, this did **not** show a measurable win — numbers were noisier than the effect I was looking for (one benchmark that doesn't even call `isEmptyImpl`, `deriveChain`, moved +86% between runs on the same machine, so that's environment noise, not signal). Best guess at why: even a 100-branch alternation likely only produces a few hundred reachable states, and the per-state cost (`nullableImpl`, `deriveAt`, `partitionReps`) dominates over the list-copy overhead at that scale — the O(n²) behavior would need a much larger state space (thousands+) to show up clearly, which isn't easy to construct with realistic patterns under `maxRepeatBound`.

Shipping this anyway as a sound complexity fix (removes a real algorithmic pitfall for pathological cases) rather than a benchmark-proven win — flagging that explicitly rather than overclaiming.

## Test plan
- [x] `scala-cli test . --exclude "bench/**"` — all suites green
- [x] `scala-cli --power fmt --check .`
- [x] Local benchmark comparison vs `main` (inconclusive, see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)