### PR TITLE
perf: avoid Option allocation in hot paths, cache Regex#nullable

### DIFF
--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -1,6 +1,6 @@
 package halotukozak.regex
 
-import scala.annotation.{publicInBinary, tailrec}
+import scala.annotation.{publicInBinary, tailrec, threadUnsafe}
 import scala.quoted.{Expr, Quotes, ToExpr, Varargs}
 import scala.util.control.TailCalls.{done, tailcall, TailRec}
 import scala.util.hashing.MurmurHash3
@@ -63,6 +63,21 @@ enum Regex:
    */
   override lazy val hashCode: Int = MurmurHash3.caseClassHash(this)
 
+  /**
+   * Cached: nullability is invariant per node but gets re-queried by `Subset.deriveImpl`'s
+   * `Concat` case on every derivative step (once per representative char, for every `Concat`
+   * node on the path) — recomputing structurally every time would re-walk the same subtree
+   * over and over during Brzozowski derivative exploration.
+   */
+  @threadUnsafe lazy val nullable: Boolean = this match
+    case Eps => true
+    case Empty | Chars(_) => false
+    case Concat(a, b) => a.nullable && b.nullable
+    case Alt(parts) => parts.exists(_.nullable)
+    case Inter(parts) => parts.forall(_.nullable)
+    case Star(_) => true
+    case Compl(inner) => !inner.nullable
+
   /** Concatenation: `this · other`. */
   infix def concat(other: Regex): Regex =
     def loop(a: Regex, b: Regex): TailRec[Regex] = (a, b) match
@@ -90,6 +105,8 @@ enum Regex:
     case s: Regex.Star => s
     case _ => Regex.Star(this)
 
+  def * = star
+
   /** Quantifier `this{n,m}` where m can be `Int.MaxValue` for unbounded. */
   def repeat(lo: Int, hi: Int): Regex =
     require(lo >= 0 && hi >= lo, s"invalid bounds {$lo,$hi}")
@@ -99,7 +116,7 @@ enum Regex:
     )
     val mandatory = (1 to lo).foldLeft[Regex](Regex.Eps)((acc, _) => this.concat(acc))
     if hi == Int.MaxValue then mandatory.concat(star)
-    else mandatory.concat((1 to (hi - lo)).foldLeft[Regex](Regex.Eps)((acc, _) => Regex.Eps | (this.concat(acc))))
+    else mandatory.concat((1 to (hi - lo)).foldLeft[Regex](Regex.Eps)((acc, _) => Regex.Eps | this.concat(acc)))
 
 object Regex:
 
@@ -143,14 +160,14 @@ object Regex:
     else
       val (chars, rest) = seq.partitionIsInstance[Chars]
       val merged =
-        if chars.sizeIs <= 1 then Some(seq)
+        if chars.sizeIs <= 1 then seq
         else
           val isect = chars.iterator.map(_.set).reduce(_ intersect _)
-          Option.unless(isect.isEmpty)(rest + Chars(isect))
+          if isect.isEmpty then null else rest + Chars(isect)
       merged match
-        case None => Empty
-        case Some(m) if m.sizeIs == 1 => m.head
-        case Some(m) => Inter(m)
+        case null => Empty
+        case m if m.sizeIs == 1 => m.head
+        case m => Inter(m)
 
   /** All-strings regex `Σ*`. */
   val all: Regex = Regex(CharSet.all).star
@@ -262,14 +279,14 @@ private[regex] object CharSet:
   def normalize(rs: Iterable[Range]): CharSet =
     val (acc, last) = rs.toVector
       .sortBy(_.lo)
-      .foldLeft((Vector.empty[Range], Option.empty[Range])):
-        case ((acc, None), r) => (acc, Some(r))
-        case ((acc, Some(cur)), r) =>
-          if r.lo <= cur.hi + 1 then (acc, Some(Range(cur.lo, math.max(cur.hi, r.hi))))
-          else (acc :+ cur, Some(r))
+      .foldLeft((Vector.empty[Range], null: Range | Null)):
+        case ((acc, null), r) => (acc, r)
+        case ((acc, cur: Range), r) =>
+          if r.lo <= cur.hi + 1 then (acc, Range(cur.lo, math.max(cur.hi, r.hi)))
+          else (acc :+ cur, r)
     CharSet(last match
-      case None => acc
-      case Some(r) => acc :+ r)
+      case null => acc
+      case r => acc :+ r)
 
   def normalize(ranges: Range*): CharSet = normalize(ranges)
 

--- a/regex/RegexParser.scala
+++ b/regex/RegexParser.scala
@@ -244,9 +244,8 @@ object RegexParser:
       (cur: @switch) match
         case '\\' =>
           pos += 1
-          readEscapedChar(inClass = true) match
-            case Left(_) => fail("shorthand escapes (\\d, \\s, \\w, ...) are not supported inside character classes")
-            case Right(c) => c
+          readEscapedChar(inClass = true).getOrElse:
+            fail("shorthand escapes (\\d, \\s, \\w, ...) are not supported inside character classes")
         case _ => consume().toInt
 
     private def parseEscape(): Regex =

--- a/regex/Subset.scala
+++ b/regex/Subset.scala
@@ -43,7 +43,7 @@ object Subset:
     def isEmpty: Boolean = isEmptyImpl(a)
 
     /** `true` iff `ε ∈ L(a)`. */
-    def nullable: Boolean = nullableImpl(a).result
+    def nullable: Boolean = a.nullable
 
     /** Brzozowski derivative of `a` with respect to code point `c`. */
     def derive(c: Int): Subset = deriveImpl(a, c).result
@@ -53,47 +53,14 @@ object Subset:
       queue.dequeueOption match
         case None => done(true)
         case Some((s, rest)) =>
-          for
-            isNull <- tailcall(nullableImpl(s))
-            out <-
-              if isNull then done(false)
-              else
-                for
-                  derived <- tailcall(deriveAt(partitionReps(s), s, Nil))
-                  next = derived.filterNot(visited.contains)
-                  r <- tailcall(loop(rest.enqueueAll(next), visited ++ next))
-                yield r
-          yield out
+          if s.nullable then done(false)
+          else
+            for
+              derived <- tailcall(deriveAt(partitionReps(s), s, Nil))
+              next = derived.filterNot(visited.contains)
+              r <- tailcall(loop(rest.enqueueAll(next), visited ++ next))
+            yield r
     loop(Queue(r), Set(r)).result
-
-  private def nullableImpl(r: Regex): TailRec[Boolean] = r match
-    case Eps => done(true)
-    case Empty | Chars(_) => done(false)
-    case Concat(a, b) =>
-      for
-        na <- tailcall(nullableImpl(a))
-        out <- if na then tailcall(nullableImpl(b)) else done(false)
-      yield out
-    case Alt(parts) => anyNullable(parts.toList)
-    case Inter(parts) => allNullable(parts.toList)
-    case Star(_) => done(true)
-    case Compl(inner) => tailcall(nullableImpl(inner)).map(!_)
-
-  private def anyNullable(parts: List[Regex]): TailRec[Boolean] = parts match
-    case Nil => done(false)
-    case head :: tail =>
-      for
-        hd <- tailcall(nullableImpl(head))
-        out <- if hd then done(true) else tailcall(anyNullable(tail))
-      yield out
-
-  private def allNullable(parts: List[Regex]): TailRec[Boolean] = parts match
-    case Nil => done(true)
-    case head :: tail =>
-      for
-        hd <- tailcall(nullableImpl(head))
-        out <- if !hd then done(false) else tailcall(allNullable(tail))
-      yield out
 
   private def deriveImpl(r: Regex, c: Int): TailRec[Regex] = r match
     case Eps | Empty => done(Empty)
@@ -101,9 +68,8 @@ object Subset:
     case Concat(a, b) =>
       for
         da <- tailcall(deriveImpl(a, c))
-        na <- tailcall(nullableImpl(a))
         out <-
-          if na then tailcall(deriveImpl(b, c)).map(db => (da.concat(b)) | db)
+          if a.nullable then tailcall(deriveImpl(b, c)).map(db => da.concat(b) | db)
           else done(da.concat(b))
       yield out
     case Alt(parts) => deriveAll(parts.toList, c, Nil).map(Regex.alt)


### PR DESCRIPTION
## Summary
- `CharSet.normalize` and `Regex.inter` swap `Option`-based accumulators for `null`-based checks (`-Yexplicit-nulls`) on construction hot paths, avoiding an allocation per step.
- `Regex#nullable` is now a cached `@threadUnsafe lazy val`, mirroring the existing `hashCode` caching (`perf/cache-regex-hashcode`). `Subset.deriveImpl`'s `Concat` case re-queries the left operand's nullability on every derivative step; recomputing it structurally each time re-walks the same subtree repeatedly during Brzozowski derivative exploration.

## Why `@threadUnsafe`
Local benchmarking (JMH, `SubsetBenchmark`) surfaced a real pitfall: a plain `lazy val nullable` regressed `subsetCheck` by >100% locally. Root cause: default Scala 3 `lazy val` synchronization (double-checked locking) is paid on every first access, and BFS-heavy paths (`isEmpty`/`subset`) visit many freshly-constructed, never-revisited nodes — so the lock overhead dominates with no reuse benefit. `@threadUnsafe` drops the synchronization; recomputation-on-race is harmless since `nullable` is a pure, deterministic, idempotent function of an immutable tree.

Even with the fix, local numbers on this laptop remain noisy (wide JMH confidence intervals on some iterations) — opening this PR so the CI `benchmark` job (cleaner, dedicated runner, same current-vs-main harness) can give a more trustworthy read before merging.

## Test plan
- [x] `scala-cli --power test . --exclude "bench/**"` — all existing tests pass (154 cases)
- [x] `scala-cli --power fmt --check .`
- [ ] CI `benchmark` job comparison (current vs `main`) — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M177yy3d177rj1BcYx7A6L