### PR TITLE
perf: cache Regex#alphabetBoundaries, avoid re-walking tree per BFS state

### DIFF
--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -1,6 +1,7 @@
 package halotukozak.regex
 
 import scala.annotation.{publicInBinary, tailrec, threadUnsafe}
+import scala.collection.immutable.SortedSet
 import scala.quoted.{Expr, Quotes, ToExpr, Varargs}
 import scala.util.control.TailCalls.{done, tailcall, TailRec}
 import scala.util.hashing.MurmurHash3
@@ -77,6 +78,24 @@ enum Regex:
     case Inter(parts) => parts.forall(_.nullable)
     case Star(_) => true
     case Compl(inner) => !inner.nullable
+
+  /**
+   * Cached: sorted boundary points (range starts, and one-past-the-end of range ends) of
+   * every [[Chars]] leaf reachable from this node — the raw material `Subset.partitionReps`
+   * combines with the sentinels `0`/`CharSet.maxCodePoint + 1` to pick one representative
+   * code point per equivalence class of the alphabet partition. This is queried once per
+   * BFS state during `Subset.isEmptyImpl`/`subset`; recomputing it by re-walking the whole
+   * subtree on every state (most of which share large unchanged substructures across
+   * consecutive derivative steps) would repeatedly re-derive the same per-node result.
+   */
+  @threadUnsafe lazy val alphabetBoundaries: SortedSet[Int] = this match
+    case Eps | Empty => SortedSet.empty
+    case Chars(set) => SortedSet.from(set.ranges.iterator.flatMap(r => Iterator(r.lo, r.hi + 1)))
+    case Concat(a, b) => a.alphabetBoundaries ++ b.alphabetBoundaries
+    case Alt(parts) => parts.iterator.map(_.alphabetBoundaries).reduce(_ ++ _)
+    case Inter(parts) => parts.iterator.map(_.alphabetBoundaries).reduce(_ ++ _)
+    case Star(inner) => inner.alphabetBoundaries
+    case Compl(inner) => inner.alphabetBoundaries
 
   /** Concatenation: `this · other`. */
   infix def concat(other: Regex): Regex =

--- a/regex/Subset.scala
+++ b/regex/Subset.scala
@@ -99,32 +99,4 @@ object Subset:
    * yield the same residual, so testing one representative suffices.
    */
   private def partitionReps(r: Regex): List[Int] =
-    val boundaries = collectBoundaries(r, SortedSet[Int](0, CharSet.maxCodePoint + 1)).result.toVector
-    boundaries.init.toList
-
-  private def collectBoundaries(r: Regex, acc: SortedSet[Int]): TailRec[SortedSet[Int]] = r match
-    case Eps | Empty => done(acc)
-    case Chars(set) => tailcall(addBoundaries(set.ranges.toList, acc))
-    case Concat(a, b) =>
-      for
-        a1 <- tailcall(collectBoundaries(a, acc))
-        a2 <- tailcall(collectBoundaries(b, a1))
-      yield a2
-    case Alt(parts) => collectAllBoundaries(parts.toList, acc)
-    case Inter(parts) => collectAllBoundaries(parts.toList, acc)
-    case Star(inner) => tailcall(collectBoundaries(inner, acc))
-    case Compl(inner) => tailcall(collectBoundaries(inner, acc))
-
-  private def addBoundaries(ranges: List[Range], acc: SortedSet[Int]): TailRec[SortedSet[Int]] =
-    ranges match
-      case Nil => done(acc)
-      case head :: tail => tailcall(addBoundaries(tail, acc + head.lo + (head.hi + 1)))
-
-  private def collectAllBoundaries(parts: List[Regex], acc: SortedSet[Int]): TailRec[SortedSet[Int]] =
-    parts match
-      case Nil => done(acc)
-      case head :: tail =>
-        for
-          next <- tailcall(collectBoundaries(head, acc))
-          out <- tailcall(collectAllBoundaries(tail, next))
-        yield out
+    (SortedSet(0, CharSet.maxCodePoint + 1) ++ r.alphabetBoundaries).init.toList


### PR DESCRIPTION
## Summary
- `Subset.partitionReps` re-walked the whole regex tree from scratch (via `collectBoundaries`/`addBoundaries`/`collectAllBoundaries`) on every single BFS state visited by `isEmptyImpl`/`subset`, to collect the `Chars`-leaf boundary points needed to pick derivative representatives.
- Since consecutive derivative steps frequently share large unchanged substructures (e.g. `Concat`'s untouched right operand, `Star`'s self-reference), most of that walk was repeated work.
- `Regex#alphabetBoundaries` (`@threadUnsafe lazy val`, same pattern as the existing `hashCode`/`nullable` caching from #9) makes each node's own boundary contribution O(1) after first computation, so `partitionReps` only pays for combining already-cached per-node results. This drops `collectBoundaries`/`addBoundaries`/`collectAllBoundaries` entirely.

## Benchmarks (local, JMH, current vs main, `-f 2 -wi 5 -i 8 -w/-r 500ms`)
| Benchmark | main | current | Δ |
|---|---|---|---|
| `isEmptyCheckManyStates` | 977.7 us/op | 237.9 us/op | 🟢 -75.7% |
| `isEmptyCheckWorstCase` | 26.7 us/op | 21.1 us/op | 🟢 -20.7% |
| `isEmptyCheck` | 751.4 us/op | 606.5 us/op | 🟢 -19.3% |
| `subsetCheckNegative` | 2008.5 us/op | 1713.4 us/op | 🟢 -14.7% |
| `subsetCheck` | 3457.7 us/op | 3126.3 us/op | ⚪ -9.6% |
| `deriveChain` | 6.18 us/op | 11.4 us/op | 🔴 +84.7%* |

\* `deriveChain` doesn't call `partitionReps` at all, and its own sample was a single noisy iteration (min 5.3us/max 27.6us/stdev 8.2 on an 11.4us mean, vs a clean 6.18us ±0.16 on main) — not attributable to this change. `isEmptyCheckManyStates` is the benchmark specifically designed to stress the BFS at scale (added in #8), and its -75.7% is the strongest signal here.

## Test plan
- [x] `scala-cli --power test . --exclude "bench/**"` against current `main` — all existing tests pass
- [x] `scala-cli --power fmt --check .`
- [ ] CI `benchmark` job comparison (current vs `main`) — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M177yy3d177rj1BcYx7A6L