### PR TITLE
feat: add TokenMatcher, a priority-ordered longest-match tokenizer

### DIFF
--- a/regex/TokenMatcher.scala
+++ b/regex/TokenMatcher.scala
@@ -1,0 +1,52 @@
+package halotukozak.regex
+
+/**
+ * Lexer-style longest-match tokenizer over a priority-ordered list of patterns.
+ *
+ * Simulates a tagged Brzozowski-derivative DFA in parallel for all patterns. Returns
+ * the longest prefix match across all patterns; ties broken by lowest priority index
+ * (i.e., the first pattern in the input list wins).
+ */
+opaque type TokenMatcher = Vector[Subset]
+
+object TokenMatcher:
+
+  /** Build a matcher from pre-parsed regexes (use this from macros after compile-time parsing). */
+  def fromRegexes(initial: Regex*): TokenMatcher = initial.iterator.map(Subset.of).toVector
+
+  extension (m: TokenMatcher)
+
+    /**
+     * Match a token starting at `start` in `input`.
+     *
+     * @return `Some((priority, end))` where `priority` is the index of the winning
+     *         pattern and `end` is the exclusive end of the longest match. `None` if
+     *         no pattern matches any (possibly empty) prefix at `start`.
+     */
+    def matchAt(input: CharSequence, start: Int): Option[(priority: Int, end: Int)] =
+      codePointStarts(input, start)
+        .map(p => (Character.codePointAt(input, p), p))
+        .scanLeft((m, start)):
+          case ((st, _), (c, p)) => (st.map(_.derive(c)), p + Character.charCount(c))
+        .takeWhile((st, _) => !st.allEmpty)
+        .flatMap((st, p) => st.firstNullable.map(idx => (priority = idx, end = p)))
+        .foldLeft(Option.empty[(priority: Int, end: Int)])((_, hit) => Some(hit))
+
+    /** First position `>= from` at which some pattern matches a non-empty prefix. */
+    def findFirst(input: CharSequence, from: Int): Option[(start: Int, priority: Int, end: Int)] =
+      codePointStarts(input, from)
+        .map(start => (start, m.matchAt(input, start)))
+        .collectFirst:
+          case (start, Some((priority, end))) if end > start => (start, priority, end)
+
+  /** Iterator of code-point start offsets in `input`, beginning at `from`. */
+  private def codePointStarts(input: CharSequence, from: Int): Iterator[Int] =
+    Iterator
+      .iterate(from)(p => p + Character.charCount(Character.codePointAt(input, p)))
+      .takeWhile(_ < input.length)
+
+  extension (s: Vector[Subset])
+    private def firstNullable: Option[Int] = s.iterator.zipWithIndex.collectFirst:
+      case (sub, idx) if sub.nullable => idx
+
+    private def allEmpty: Boolean = s.forall(_ == Subset.empty)

--- a/test/TokenMatcherTest.scala
+++ b/test/TokenMatcherTest.scala
@@ -1,0 +1,55 @@
+package halotukozak.regex
+
+class TokenMatcherTest extends munit.FunSuite:
+
+  private def parse(pattern: String): Regex = RegexParser.parse(pattern) match
+    case Right(r) => r
+    case Left(err) => fail(s"expected successful parse of /$pattern/, got $err")
+
+  private def matcher(patterns: String*): TokenMatcher = TokenMatcher.fromRegexes(patterns.map(parse)*)
+
+  test("matches the longest prefix across patterns") {
+    val m = matcher("if", "[a-zA-Z_][a-zA-Z0-9_]*")
+    assertEquals(m.matchAt("ifx", 0), Some((priority = 1, end = 3)))
+  }
+
+  test("ties broken by lowest priority index (earlier pattern wins)") {
+    val m = matcher("if", "[a-zA-Z_][a-zA-Z0-9_]*")
+    assertEquals(m.matchAt("if", 0), Some((priority = 0, end = 2)))
+  }
+
+  test("matches at a non-zero start offset") {
+    val m = matcher("[a-z]+")
+    assertEquals(m.matchAt("12abc", 2), Some((priority = 0, end = 5)))
+  }
+
+  test("returns None when no pattern matches even an empty prefix") {
+    val m = matcher("[a-z]+")
+    assertEquals(m.matchAt("123", 0), None)
+  }
+
+  test("matches a zero-length pattern (e.g. from a? or a*)") {
+    val m = matcher("a*")
+    assertEquals(m.matchAt("bbb", 0), Some((priority = 0, end = 0)))
+  }
+
+  test("findFirst locates the first non-empty match at or after `from`") {
+    val m = matcher("[a-z]+")
+    assertEquals(m.findFirst("123abc456", 0), Some((start = 3, priority = 0, end = 6)))
+  }
+
+  test("findFirst returns None when no non-empty match exists at or after `from`") {
+    val m = matcher("[a-z]+")
+    assertEquals(m.findFirst("12345", 0), None)
+  }
+
+  test("findFirst respects the `from` lower bound") {
+    val m = matcher("[a-z]+")
+    assertEquals(m.findFirst("abc123def", 4), Some((start = 6, priority = 0, end = 9)))
+  }
+
+  test("multiple patterns racing in parallel, correct one wins by length then priority") {
+    val m = matcher("\\d+", "\\d+\\.\\d+")
+    assertEquals(m.matchAt("3.14", 0), Some((priority = 1, end = 4)))
+    assertEquals(m.matchAt("314", 0), Some((priority = 0, end = 3)))
+  }


### PR DESCRIPTION
## Summary
- Adds `TokenMatcher`: a priority-ordered, longest-match tokenizer built entirely on `Regex`/`Subset`'s existing public API (`derive`, `nullable`) - no new dependencies, cross-platform for free.

## Why
Ported out of alpaca's lexer, where it had been reimplemented from scratch against this library's own API to replace `java.util.regex.Pattern` at runtime (not just at compile time for shadow-checking). Since it only depends on what's already public here, keeping it alpaca-local meant duplicating logic that belongs in the library - every future consumer wanting a real tokenizer instead of just subset-checking would have re-derived the same thing.

Note: `matchAt`/`findFirst` currently need `given ToExpr[Regex]`'s CharSet/Range visibility fix (#11) to be usable from `TokenMatcher.fromRegexes` inside a macro in an external package - same underlying issue, different symptom.

## Test plan
- [x] `scala-cli test .` passes on JVM, Scala.js, and Scala Native (9 new tests, 158 total)