### PR TITLE
perf: avoid TailRec trampoline allocation for flat list walks

### DIFF
--- a/regex/Subset.scala
+++ b/regex/Subset.scala
@@ -2,6 +2,7 @@ package halotukozak.regex
 
 import halotukozak.regex.Regex.*
 
+import scala.annotation.tailrec
 import scala.collection.immutable.{Queue, SortedSet}
 import scala.util.control.TailCalls.{done, tailcall, TailRec}
 
@@ -55,11 +56,9 @@ object Subset:
         case Some((s, rest)) =>
           if s.nullable then done(false)
           else
-            for
-              derived <- tailcall(deriveAt(partitionReps(s), s, Nil))
-              next = derived.filterNot(visited.contains)
-              r <- tailcall(loop(rest.enqueueAll(next), visited ++ next))
-            yield r
+            val derived = deriveAt(partitionReps(s), s, Nil)
+            val next = derived.filterNot(visited.contains)
+            tailcall(loop(rest.enqueueAll(next), visited ++ next))
     loop(Queue(r), Set(r)).result
 
   private def deriveImpl(r: Regex, c: Int): TailRec[Regex] = r match
@@ -72,26 +71,37 @@ object Subset:
           if a.nullable then tailcall(deriveImpl(b, c)).map(db => da.concat(b) | db)
           else done(da.concat(b))
       yield out
-    case Alt(parts) => deriveAll(parts.toList, c, Nil).map(Regex.alt)
-    case Inter(parts) => deriveAll(parts.toList, c, Nil).map(Regex.inter)
+    case Alt(parts) => done(Regex.alt(deriveAll(parts.toList, c, Nil)))
+    case Inter(parts) => done(Regex.inter(deriveAll(parts.toList, c, Nil)))
     case s @ Star(inner) => tailcall(deriveImpl(inner, c)).map(d => d.concat(s))
     case Compl(inner) => tailcall(deriveImpl(inner, c)).map(!_)
 
-  private def deriveAll(parts: List[Regex], c: Int, acc: List[Regex]): TailRec[List[Regex]] = parts match
-    case Nil => done(acc)
-    case head :: tail =>
-      for
-        d <- tailcall(deriveImpl(head, c))
-        out <- tailcall(deriveAll(tail, c, d :: acc))
-      yield out
+  /**
+   * Plain `@tailrec` loops, not `TailRec`-trampolined: unlike `deriveImpl`'s tree recursion
+   * (whose depth tracks regex structure and needs the heap-based trampoline for stack
+   * safety), these only walk a flat list — `parts`/`reps` — whose length is bounded by
+   * branch/partition count, not tree depth. Composing them through `tailcall`/`for` would
+   * still be stack-safe but pays for a `Cont` continuation-object allocation per list
+   * element; forcing each `deriveImpl(...).result` eagerly here avoids that allocation.
+   *
+   * Trade-off: each forced `.result` is a real (non-tail) JVM call into `deriveImpl`, so an
+   * `Alt`/`Inter` node nested inside another `Alt`/`Inter`'s part now grows the JVM call
+   * stack by one frame per nesting level, instead of being folded into the single top-level
+   * trampoline as before. Verified this stays within the JVM's minimum stack size
+   * (`-Xss208k`) for the worst case the library's own `maxRepeatBound` allows (one `{0,1000}`
+   * quantifier); deliberately-adversarial nesting far beyond that bound can still overflow —
+   * same pre-existing ceiling `Regex#hashCode`/`nullable`/`alphabetBoundaries` already have,
+   * since those are also plain structural recursion, not trampolined.
+   */
+  @tailrec
+  private def deriveAll(parts: List[Regex], c: Int, acc: List[Regex]): List[Regex] = parts match
+    case Nil => acc
+    case head :: tail => deriveAll(tail, c, deriveImpl(head, c).result :: acc)
 
-  private def deriveAt(reps: List[Int], r: Regex, acc: List[Regex]): TailRec[List[Regex]] = reps match
-    case Nil => done(acc)
-    case c :: tail =>
-      for
-        d <- tailcall(deriveImpl(r, c))
-        out <- tailcall(deriveAt(tail, r, d :: acc))
-      yield out
+  @tailrec
+  private def deriveAt(reps: List[Int], r: Regex, acc: List[Regex]): List[Regex] = reps match
+    case Nil => acc
+    case c :: tail => deriveAt(tail, r, deriveImpl(r, c).result :: acc)
 
   /**
    * Returns one representative code point per equivalence class of the alphabet


### PR DESCRIPTION
## Summary
`deriveAll` and `deriveAt` only iterate a flat list (`Alt`/`Inter` parts, alphabet-partition representatives) whose length is bounded by branch/partition count, not tree depth — unlike `deriveImpl`'s genuine tree recursion, which does need `TailRec`'s heap-based trampoline for stack safety. Composing the list walk through `tailcall`/`for` still worked, but built a `Cont` continuation-object chain, one per list element, purely to thread values through.

Converted both to plain `@tailrec` loops that force each `deriveImpl(...).result` eagerly (`deriveImpl` keeps its own trampoline internally), eliminating that continuation-chain allocation.

## Stack-safety trade-off (please read)
This is not a free lunch, and I want to be upfront about it rather than bury it in the diff.

An `Alt`/`Inter` nested inside another `Alt`/`Inter`'s part now costs one real JVM call frame per nesting level, where before it was folded into the single top-level trampoline. I verified empirically (constructing patterns with `-Xss` down to the JVM's absolute minimum, 208k) that a regex built from the library's own enforced `maxRepeatBound` (1000) still derives fine even at that minimum stack size — so this doesn't shrink the practically-reachable envelope.

Deliberately-adversarial nesting far beyond that bound (e.g. `repeat(0,1000)` nested inside another `repeat(0,1000)`) can overflow — but I confirmed this ceiling already exists today, independent of this change: `Regex#hashCode`/`nullable`/`alphabetBoundaries` are plain structural recursion (not trampolined), and that pathological case already overflows the stack **at construction time** on current `main`, before derivation is ever involved. So this PR doesn't introduce a new class of vulnerable input, it marginally narrows the safety margin within a ceiling that was already there.

Full reasoning is in the code comment above `deriveAll`/`deriveAt`.

## Benchmarks (local, JMH, current vs `main` @ 047b50c — predates both this and #10's `alphabetBoundaries` change, so the numbers show the combined effect — `-f 2 -wi 5 -i 8 -w/-r 500ms`)
| Benchmark | main | current | Δ |
|---|---|---|---|
| `isEmptyCheckManyStates` | 977.7 us/op | 127.0 us/op | 🟢 -87.0% |
| `isEmptyCheckWorstCase` | 26.7 us/op | 16.5 us/op | 🟢 -38.1% |
| `isEmptyCheck` | 751.4 us/op | 501.3 us/op | 🟢 -33.3% |
| `subsetCheckNegative` | 2008.5 us/op | 1434.0 us/op | 🟢 -28.6% |
| `subsetCheck` | 3457.7 us/op | 2628.1 us/op | 🟢 -24.0% |
| `deriveChain` | 6.18 us/op | 4.60 us/op | 🟢 -25.6% |

No regressions on any benchmark in this comparison.

## Test plan
- [x] `scala-cli --power test . --exclude "bench/**"` against current `main` — all existing tests pass
- [x] `scala-cli --power fmt --check .`
- [x] Manual stack-safety probe: `(a|b).repeat(0, 1000)` derived/isEmpty-checked successfully at `-Xss208k` (JVM's absolute minimum stack size)
- [ ] CI `benchmark` job comparison (current vs `main`) — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M177yy3d177rj1BcYx7A6L