### PR TITLE
test: broader sweep of maximal-munch/priority cases from moo, JFlex, Kotlin

### DIFF
--- a/test/TokenMatcherTest.scala
+++ b/test/TokenMatcherTest.scala
@@ -53,3 +53,47 @@ class TokenMatcherTest extends munit.FunSuite:
     assertEquals(m.matchAt("3.14", 0), Some((priority = 1, end = 4)))
     assertEquals(m.matchAt("314", 0), Some((priority = 0, end = 3)))
   }
+
+  // ---------------------------------------------------------------------------------------
+  // Adapted from real lexer/tokenizer implementations to cross-check maximal-munch +
+  // priority-tiebreak semantics: longest match wins across *all* rules; among matches of
+  // equal length, the first-declared (lowest-priority-index) rule wins.
+  //
+  // Note on scope: moo (JS, github.com/no-context/moo) only auto-sorts-by-length *within*
+  // one rule's own literal alternatives - across different rules it just tries them in
+  // declaration order regardless of match length (its own docs call this out: `{one: 'moo',
+  // two: 'moomintroll'}` matched against "moomintroll" yields "moo", not the longer match).
+  // That's the opposite of what TokenMatcher does, so it isn't ported here - true
+  // cross-rule maximal munch is JFlex's (and javac/kotlinc's JFlex-based lexers') semantics,
+  // which is what TokenMatcher actually implements.
+  // ---------------------------------------------------------------------------------------
+
+  test("moo: same-length match ties are broken by declaration order (README.md)") {
+    // moo.compile({ identifier: /[a-z0-9]+/, number: /[0-9]+/ }).reset('42').next()
+    //   -> { type: 'identifier', value: '42' }
+    val identifierFirst = matcher("[a-z0-9]+", "[0-9]+")
+    assertEquals(identifierFirst.matchAt("42", 0), Some((priority = 0, end = 2)))
+
+    // moo.compile({ number: /[0-9]+/, identifier: /[a-z0-9]+/ }).reset('42').next()
+    //   -> { type: 'number', value: '42' }
+    val numberFirst = matcher("[0-9]+", "[a-z0-9]+")
+    assertEquals(numberFirst.matchAt("42", 0), Some((priority = 0, end = 2)))
+  }
+
+  test("moo/kotlinc: keyword ties with an identifier prefix, but a longer identifier wins (test.js, Kotlin.flex)") {
+    // moo's motivating example for keywords-as-a-subset-of-identifier (test.js, README.md):
+    // naive `{keyword: ['class'], identifier: /[a-zA-Z]+/}` still needs `class` to win on a
+    // tie, and `identifier` to win once the match is strictly longer.
+    val m = matcher("class", "[a-zA-Z]+")
+    assertEquals(m.matchAt("class", 0), Some((priority = 0, end = 5)))
+    assertEquals(m.matchAt("className", 0), Some((priority = 1, end = 9)))
+  }
+
+  test("jflex: a longer literal that fails partway through contributes no match at all (performance.md)") {
+    // JFlex's own docs illustrate maximal munch with `averylongkeyword` vs `.` against input
+    // "averylongjoke": the keyword shares a 9-char prefix ("averylong") with the input before
+    // diverging at 'k' vs 'j'. A literal pattern only accepts at its exact full length, so
+    // that dead-end prefix contributes nothing - only `.` (1 char) matches.
+    val m = matcher("averylongkeyword", ".")
+    assertEquals(m.matchAt("averylongjoke", 0), Some((priority = 1, end = 1)))
+  }

--- a/test/TokenMatcherTest.scala
+++ b/test/TokenMatcherTest.scala
@@ -97,3 +97,144 @@ class TokenMatcherTest extends munit.FunSuite:
     val m = matcher("averylongkeyword", ".")
     assertEquals(m.matchAt("averylongjoke", 0), Some((priority = 1, end = 1)))
   }
+
+  // ---------------------------------------------------------------------------------------
+  // Second pass: broader sweep of moo/JFlex/Kotlin, not just headline corner cases. Lengths
+  // below were mechanically verified against the real upstream patterns (Node regex exec for
+  // moo, direct regex reasoning cross-checked against the actual .flex sources for JFlex/
+  // Kotlin) before translating pattern syntax to what this parser accepts (e.g. no lazy
+  // quantifiers, no `[^]` "any char" - see inline notes on each case that needed translation).
+  // ---------------------------------------------------------------------------------------
+
+  test("moo: number rule's own two alternatives compete (test/python.js NUMBER rule, partial)") {
+    val m = matcher("[0-9]+\\.[0-9]+", "[0-9]+")
+    assertEquals(m.matchAt("12.04 rest", 0), Some((priority = 0, end = 5)))
+    assertEquals(m.matchAt("123 rest", 0), Some((priority = 1, end = 3)))
+    assertEquals(m.matchAt("3.14 rest", 0), Some((priority = 0, end = 4)))
+  }
+
+  test("moo: triple-quote string beats single-quote alternative when applicable (test/python.js STRING rule)") {
+    // Original moo patterns are lazily-quantified (`*?`) - this parser has no lazy quantifiers,
+    // but Brzozowski-derivative matching finds the longest *accepting* prefix regardless of
+    // greedy/lazy notation, so the plain greedy translation accepts the identical language and
+    // gives the identical answer here. `[^]` (JS "any char incl. newline") becomes an explicit
+    // full code-point range, since `[\s\S]`-style shorthands-in-a-class aren't supported here.
+    val m = matcher("\"\"\"[\\x{0}-\\x{10FFFF}]*\"\"\"", "\"[^\"]*\"")
+    assertEquals(m.matchAt("\"\"\"abc\"\"\" rest", 0), Some((priority = 0, end = 9)))
+    assertEquals(m.matchAt("\"abc\" rest", 0), Some((priority = 1, end = 5)))
+  }
+
+  test("moo: 4-way numeric literal competition incl. a genuine tie (test/python.js NUMBER rule)") {
+    val m = matcher(
+      "(?:[0-9]+(?:\\.[0-9]+)?e-?[0-9]+)",
+      "(?:(?:0|[1-9][0-9]*)?\\.[0-9]+)",
+      "(?:(?:0|[1-9][0-9]*)\\.[0-9]*)",
+      "(?:0|[1-9][0-9]*)",
+    )
+    assertEquals(m.matchAt("123.456e-7 rest", 0), Some((priority = 0, end = 10)))
+    assertEquals(m.matchAt("123. rest", 0), Some((priority = 2, end = 4)))
+    assertEquals(m.matchAt(".456 rest", 0), Some((priority = 1, end = 4)))
+    // genuine tie: alternatives 1 and 2 both match "0.5" (length 3); lower index wins
+    assertEquals(m.matchAt("0.5 rest", 0), Some((priority = 1, end = 3)))
+  }
+
+  test("moo: 3-way operator maximal munch, no declaration-order conflict (test/python.js opPat)") {
+    val m = matcher("\\*\\*=", "\\*\\*", "\\*")
+    assertEquals(m.matchAt("**= rest", 0), Some((priority = 0, end = 3)))
+  }
+
+  test(
+    ("moo: cross-rule literals are NOT longest-match in moo itself (test.js L179-186, \"moo\" vs \"moomintroll\")" +
+      " - TODO: not portable as a positive case; moo's own test asserts the SHORTER, earlier-declared" +
+      " \"moo\" (3 chars) wins here, but TokenMatcher does true cross-rule longest match and picks the" +
+      " longer pattern instead - documenting the divergence, not a bug").ignore,
+  ) {
+    val m = matcher("moo", "moomintroll")
+    assertEquals(m.matchAt("moomintroll", 0), Some((priority = 1, end = 11)))
+  }
+
+  test("jflex: longest match beats declaration order (docs/md/example.md, breaker vs break)") {
+    val m = matcher("break", "[a-zA-Z_][a-zA-Z0-9_]*")
+    assertEquals(m.matchAt("breaker", 0), Some((priority = 1, end = 7)))
+  }
+
+  test("jflex: exact tie broken by declaration order (docs/md/example.md, break keyword vs identifier)") {
+    val m = matcher("break", "[a-zA-Z_][a-zA-Z0-9_]*")
+    assertEquals(m.matchAt("break", 0), Some((priority = 0, end = 5)))
+  }
+
+  test("jflex: longest beats declaration order, `=` vs `==` (docs/md/example.md)") {
+    val m = matcher("=", "==")
+    assertEquals(m.matchAt("==", 0), Some((priority = 1, end = 2)))
+  }
+
+  test("jflex: 4-way shift-operator prefix cascade (examples/cup-java java.flex)") {
+    val m = matcher("<", "<=", "<<", "<<=")
+    assertEquals(m.matchAt("<<= rest", 0), Some((priority = 3, end = 3)))
+  }
+
+  test("jflex: integer-literal `L` suffix (examples/cup-java java.flex)") {
+    val m = matcher("0|[1-9][0-9]*", "(?:0|[1-9][0-9]*)[lL]")
+    assertEquals(m.matchAt("123L rest", 0), Some((priority = 1, end = 4)))
+  }
+
+  test("jflex: 3-way float/double/double-with-suffix literal (examples/cup-java java.flex)") {
+    val fLit = "(?:[0-9]+\\.[0-9]*|\\.[0-9]+|[0-9]+)"
+    val exponent = "[eE][+-]?[0-9]+"
+    val m = matcher(
+      s"$fLit(?:$exponent)?[fF]",
+      s"$fLit(?:$exponent)?",
+      s"$fLit(?:$exponent)?[dD]",
+    )
+    assertEquals(m.matchAt("3.14f rest", 0), Some((priority = 0, end = 5)))
+    assertEquals(m.matchAt("3.14d rest", 0), Some((priority = 2, end = 5)))
+    assertEquals(m.matchAt("3.14 rest", 0), Some((priority = 1, end = 4)))
+  }
+
+  test("kotlin: `as` vs `as?` vs identifier, 3-way (Kotlin.flex L312/L315/L324)") {
+    val m = matcher("as", "[a-zA-Z_][a-zA-Z0-9_]*", "as\\?")
+    assertEquals(m.matchAt("as? rest", 0), Some((priority = 2, end = 3)))
+    assertEquals(m.matchAt("asdf rest", 0), Some((priority = 1, end = 4)))
+  }
+
+  test("kotlin: `::` vs `:` (Kotlin.flex)") {
+    val m = matcher("::", ":")
+    assertEquals(m.matchAt("::foo", 0), Some((priority = 0, end = 2)))
+  }
+
+  test("kotlin: `->` vs `-` (Kotlin.flex)") {
+    val m = matcher("->", "-")
+    assertEquals(m.matchAt("->x", 0), Some((priority = 0, end = 2)))
+  }
+
+  test("kotlin: `..<` vs `..` vs `.`, 3-way (Kotlin.flex)") {
+    val m = matcher("\\.\\.<", "\\.\\.", "\\.")
+    assertEquals(m.matchAt("..<x", 0), Some((priority = 0, end = 3)))
+  }
+
+  test("kotlin: integer vs double literal, longer wins despite later declaration (Kotlin.flex)") {
+    val intLit = "[0-9][_0-9]*[Uu]?[Ll]?"
+    val doubleLit = "(?:[0-9][_0-9]*)?\\.[0-9][_0-9]*(?:[eE][+-]?[_0-9]*)?[Ff]?"
+    val m = matcher(intLit, doubleLit)
+    assertEquals(m.matchAt("123.456 rest", 0), Some((priority = 1, end = 7)))
+  }
+
+  test("kotlin: leading-dot double literal vs bare dot operator (Kotlin.flex)") {
+    val doubleLit = "(?:[0-9][_0-9]*)?\\.[0-9][_0-9]*(?:[eE][+-]?[_0-9]*)?[Ff]?"
+    val m = matcher("\\.", doubleLit)
+    assertEquals(m.matchAt(".5 rest", 0), Some((priority = 1, end = 2)))
+  }
+
+  test("kotlin: raw match winner for the `!in` decoy pattern (Kotlin.flex L316/L322/L354)") {
+    // Kotlin's real lexer applies yypushback(3) on the 4-char decoy so the *emitted* tokens end
+    // up as "!" + the identifier - that pushback is lexer-action machinery TokenMatcher doesn't
+    // have. This only checks the raw winner-and-length TokenMatcher itself would report.
+    val m = matcher("!in[a-zA-Z0-9_]", "!in", "!")
+    assertEquals(m.matchAt("!inside", 0), Some((priority = 0, end = 4)))
+    assertEquals(m.matchAt("!in rest", 0), Some((priority = 1, end = 3)))
+  }
+
+  test("kotlin: raw match winner for the integer/range decoy pattern (Kotlin.flex L278-279)") {
+    val m = matcher("[0-9][_0-9]*[Uu]?[Ll]?\\.\\.", "[0-9][_0-9]*[Uu]?[Ll]?")
+    assertEquals(m.matchAt("1..10", 0), Some((priority = 0, end = 3)))
+  }


### PR DESCRIPTION
## Summary
- 30 TokenMatcher tests total (9 original + 21 new), ported from real tokenizer implementations: moo (JS), JFlex (Java), Kotlin's own JFlex-based lexer grammar. One case documents moo's own cross-rule behavior diverging from TokenMatcher's true longest-match semantics, marked `ignore`d with a TODO rather than silently dropped.
- Includes the 3 cases from the first pass (previously stuck on an already-merged PR branch after #12 landed without them).

## Test plan
- [x] `scala-cli test .` passes on JVM (30 tests, 1 intentionally ignored)