### PR TITLE
test: add regex"..." interpolator coverage, fix its compile-time validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,25 @@ val hexDigits = digits | Regex.range('a', 'f') | Regex.range('A', 'F')
 (`RegexParseError.InvalidSyntax`) from syntax this parser recognizes but doesn't support, like
 lookaround or backreferences (`RegexParseError.UnsupportedFeature`).
 
+### `regex"..."` interpolator
+
+For a pattern that's a string literal at the call site, `regex"..."` parses it at compile time
+instead, so a malformed or unsupported pattern is a compile error rather than a `Left` you have
+to remember to handle:
+
+```scala
+import halotukozak.regex.regex
+
+val idToken = regex"[a-zA-Z_][a-zA-Z0-9_]*" // Regex, built while compiling
+
+val bad = regex"(?=foo)" // doesn't compile: Regex parse error: UnsupportedFeature(...)
+```
+
+If the pattern isn't a literal (e.g. it's assembled into a `StringContext` at runtime), it falls
+back to parsing at runtime and throws `IllegalArgumentException` on failure instead. Note that
+`${...}` splices aren't currently supported — only the literal parts of the string are used, so
+`regex"a${x}b"` parses as `"ab"`, ignoring `x`.
+
 ## Status
 
 Early (`0.x`). The parser deliberately supports a subset of `java.util.regex.Pattern`'s syntax —

--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -1,10 +1,40 @@
 package halotukozak.regex
 
-import scala.annotation.{publicInBinary, tailrec, threadUnsafe}
+import scala.annotation.{publicInBinary, tailrec, threadUnsafe, unused}
 import scala.collection.immutable.SortedSet
 import scala.quoted.{Expr, Quotes, ToExpr, Varargs}
 import scala.util.control.TailCalls.{done, tailcall, TailRec}
 import scala.util.hashing.MurmurHash3
+
+/**
+ * The `args` parameter only exists so this satisfies the shape Scala's `StringContext`
+ * interpolation desugaring requires (`sc"..."` lowers to `sc.regex(interpolatedExprs*)`); the
+ * pattern itself is built purely from the string-literal parts, so splices are not supported.
+ *
+ * `sc` must be `inline` too: without it, the compiler binds the extension receiver to a
+ * synthetic proxy val before splicing, so `'sc` inside the macro body no longer refers to the
+ * literal `StringContext(...)` call and `scExpr.value` always sees `None` — silently
+ * degrading every `regex"..."` call to the runtime-parsing fallback instead of validating at
+ * compile time.
+ */
+extension (inline sc: StringContext) inline def regex(@unused args: Any*): Regex = ${ regexInterpolatorImpl('sc) }
+
+private def regexInterpolatorImpl(scExpr: Expr[StringContext])(using quotes: Quotes): Expr[Regex] =
+  import quotes.reflect.*
+  scExpr.value match
+    case Some(sc) =>
+      val pattern = sc.parts.mkString
+      RegexParser.parse(pattern) match
+        case Left(error) =>
+          report.errorAndAbort(s"Regex parse error: $error")
+        case Right(regex) =>
+          Expr(regex)
+    case None =>
+      '{
+        RegexParser.parse(${ scExpr }.parts.mkString) match
+          case Left(error) => throw IllegalArgumentException(s"Regex parse error: $error")
+          case Right(regex) => regex
+      }
 
 /**
  * A symbolic regex algebra with exact language containment ("is this pattern a subset of

--- a/test/RegexInterpolatorTest.scala
+++ b/test/RegexInterpolatorTest.scala
@@ -1,0 +1,118 @@
+package halotukozak.regex
+
+import halotukozak.regex.Regex.*
+
+import scala.compiletime.testing.{typeCheckErrors, typeChecks}
+
+class RegexInterpolatorTest extends munit.FunSuite:
+
+  // Cross-checks: the interpolator's compile-time expansion (RegexParser.parse followed by a
+  // ToExpr[Regex] round-trip) must produce the exact same value as calling the parser directly.
+
+  test("literal string") {
+    assertEquals(regex"abc", RegexParser.parse("abc").toOption.get)
+    assertEquals(regex"abc", Regex.literal("abc"))
+  }
+
+  test("dot") {
+    assertEquals(regex".", RegexParser.parse(".").toOption.get)
+  }
+
+  test("character class with range") {
+    assertEquals(regex"[a-z]", RegexParser.parse("[a-z]").toOption.get)
+  }
+
+  test("negated character class") {
+    assertEquals(regex"[^a-z]", RegexParser.parse("[^a-z]").toOption.get)
+  }
+
+  test("alternation") {
+    assertEquals(regex"a|b", RegexParser.parse("a|b").toOption.get)
+  }
+
+  test("Kleene star, plus, and optional") {
+    assertEquals(regex"a*", RegexParser.parse("a*").toOption.get)
+    assertEquals(regex"a+", RegexParser.parse("a+").toOption.get)
+    assertEquals(regex"a?", RegexParser.parse("a?").toOption.get)
+  }
+
+  test("bounded repetition") {
+    assertEquals(regex"a{2,3}", RegexParser.parse("a{2,3}").toOption.get)
+  }
+
+  test("groups") {
+    assertEquals(regex"(a(bc))+", RegexParser.parse("(a(bc))+").toOption.get)
+  }
+
+  // IntelliJ's Scala plugin (pre-2025.2) misapplies `s`-interpolator escape-cooking rules to
+  // custom interpolators taking an `args: Any*` parameter, flagging `\d`/`\Q`/`\x` below as
+  // "Invalid escape character" — a known false positive (fixed in the 2025.2 release; update
+  // the plugin if you still see it). Scala 3 itself leaves non-builtin interpolator literals
+  // uncooked/raw (verified: `scala-cli test` compiles and passes these), so `\d` etc. reach
+  // RegexParser byte-for-byte, same as a plain "\\d" string.
+
+  test("shorthand escapes \\d \\s \\w") {
+    assertEquals(regex"\d", RegexParser.parse("\\d").toOption.get)
+    assertEquals(regex"\s", RegexParser.parse("\\s").toOption.get)
+    assertEquals(regex"\w", RegexParser.parse("\\w").toOption.get)
+  }
+
+  test("\\Q...\\E quoted literal") {
+    assertEquals(regex"\Qa.b*c\E", RegexParser.parse("\\Qa.b*c\\E").toOption.get)
+  }
+
+  test("\\x and \\u code point escapes") {
+    assertEquals(regex"\x41", RegexParser.parse("\\x41").toOption.get)
+    assertEquals(regex"A", RegexParser.parse("\\u0041").toOption.get)
+  }
+
+  // Compile-time validation: a pattern that's a literal at the call site is parsed and
+  // type-checked while compiling the interpolator call, not deferred to runtime.
+
+  test("valid literal pattern type-checks") {
+    assert(typeChecks("""_root_.scala.StringContext("a(b|c)*").regex()"""))
+  }
+
+  test("unsupported feature fails to compile with a descriptive message") {
+    val errors = typeCheckErrors("""_root_.scala.StringContext("(?=foo)").regex()""")
+    assertEquals(errors.size, 1)
+    assert(
+      errors.head.message.contains("Regex parse error") && errors.head.message.contains("UnsupportedFeature"),
+      s"unexpected message: ${errors.head.message}",
+    )
+  }
+
+  test("invalid syntax fails to compile with a descriptive message") {
+    val errors = typeCheckErrors("""_root_.scala.StringContext("(").regex()""")
+    assertEquals(errors.size, 1)
+    assert(
+      errors.head.message.contains("Regex parse error") && errors.head.message.contains("InvalidSyntax"),
+      s"unexpected message: ${errors.head.message}",
+    )
+  }
+
+  // Runtime fallback: when the StringContext isn't a compile-time constant (e.g. built up
+  // dynamically rather than written as a `regex"..."` literal), parsing happens at runtime
+  // instead, mirroring RegexParser.parse's Either result via a thrown exception on failure.
+
+  private def nonConstantParts(parts: String*): Seq[String] =
+    if System.nanoTime() != 0 then parts else Seq.empty
+
+  test("non-constant StringContext parses successfully at runtime") {
+    val sc = StringContext(nonConstantParts("a", "b")*)
+    assertEquals(sc.regex(), RegexParser.parse("ab").toOption.get)
+  }
+
+  test("non-constant StringContext throws on an invalid pattern at runtime") {
+    val sc = StringContext(nonConstantParts("(")*)
+    intercept[IllegalArgumentException](sc.regex())
+  }
+
+  // Current limitation: `args` exists only so `regex"..."` type-checks as a string
+  // interpolator; the values substituted into `${...}` holes are not incorporated into the
+  // pattern, only the literal parts are. This documents that behavior rather than endorsing it.
+
+  test("interpolated splice values are not incorporated into the pattern") {
+    val ignored = "this text never appears in the resulting pattern"
+    assertEquals(regex"a${ignored}b", Regex.literal("ab"))
+  }


### PR DESCRIPTION
## Summary
- Adds `test/RegexInterpolatorTest.scala` (17 tests): cross-checks `regex"..."` against `RegexParser.parse` across literals/classes/alternation/quantifiers/groups/escapes, compile-time validation via `scala.compiletime.testing.{typeChecks, typeCheckErrors}`, the runtime-fallback path for non-literal `StringContext`s, and a test documenting that `${...}` splice values are currently ignored.
- Fixes a real bug found while writing those tests: the extension receiver `sc` wasn't `inline`, so the compiler bound it to a synthetic proxy before splicing — `scExpr.value` always saw `None`, and every `regex"..."` call silently fell through to the runtime-parsing fallback instead of validating at compile time. Marking `sc` `inline` too fixes it; invalid patterns now correctly fail to compile.
- Documents `regex"..."` in the README (compile-time validation, runtime fallback, the splice-ignoring limitation).

Previously also carried an unrelated `CharSet.ranges` visibility refactor — split out to #26 to keep this PR to just the interpolator.

## Test plan
- [x] `scala-cli test . --exclude "bench/**"` — 0 failed, 6 ignored (pre-existing TODOs)
- [x] `scala-cli --power fmt --check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)