### PR TITLE
refactor: make CharSet.ranges private, expose via iterator

### DIFF
--- a/bench/CharSetBenchmark.scala
+++ b/bench/CharSetBenchmark.scala
@@ -23,6 +23,7 @@ class CharSetBenchmark:
   private var ranges: CharSet = uninitialized
   private var interleaved: CharSet = uninitialized
   private var reversedRanges: Vector[Range] = uninitialized
+  private var lastLo: Int = uninitialized
 
   @Setup(Level.Trial)
   def setup(): Unit =
@@ -30,10 +31,15 @@ class CharSetBenchmark:
     // Every other gap, so union/intersect actually have interleaving work to do.
     interleaved = CharSet.normalize((0 until rangeCount).map(i => Range(i * 4 + 2, i * 4 + 3)))
     reversedRanges = (0 until rangeCount).map(i => Range(i * 4, i * 4 + 1)).reverse.toVector
+    // The last input range's lo, derived from the same `i * 4` formula used to build `ranges`
+    // above rather than read back off `ranges` itself: this file also runs, unmodified, against
+    // main's `regex/` sources as the baseline half of the CI benchmark comparison job, so it
+    // can't depend on `CharSet` exposing anything beyond what main's version already does.
+    lastLo = (rangeCount - 1) * 4
 
   /** Worst case for a linear scan: the match is the very last range. */
   @Benchmark
-  def containsNearEnd(): Boolean = ranges.contains(ranges.ranges.last.lo)
+  def containsNearEnd(): Boolean = ranges.contains(lastLo)
 
   /** Best case for a linear scan: the match is the very first range. */
   @Benchmark
@@ -41,7 +47,7 @@ class CharSetBenchmark:
 
   /** A miss (falls in a gap), which still has to prove absence across the whole set. */
   @Benchmark
-  def containsMiss(): Boolean = ranges.contains(ranges.ranges.last.lo + 2)
+  def containsMiss(): Boolean = ranges.contains(lastLo + 2)
 
   @Benchmark
   def union(): CharSet = ranges.union(interleaved)

--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -2,7 +2,7 @@ package halotukozak.regex
 
 import scala.annotation.{publicInBinary, tailrec, threadUnsafe}
 import scala.collection.immutable.SortedSet
-import scala.quoted.{Expr, Quotes, ToExpr, Varargs}
+import scala.quoted.{Expr, FromExpr, Quotes, ToExpr, Varargs}
 import scala.util.control.TailCalls.{done, tailcall, TailRec}
 import scala.util.hashing.MurmurHash3
 
@@ -90,7 +90,7 @@ enum Regex:
    */
   @threadUnsafe lazy val alphabetBoundaries: SortedSet[Int] = this match
     case Eps | Empty => SortedSet.empty
-    case Chars(set) => SortedSet.from(set.ranges.iterator.flatMap(r => Iterator(r.lo, r.hi + 1)))
+    case Chars(set) => SortedSet.from(set.iterator.flatMap(r => Iterator(r.lo, r.hi + 1)))
     case Concat(a, b) => a.alphabetBoundaries ++ b.alphabetBoundaries
     case Alt(parts) => parts.iterator.map(_.alphabetBoundaries).reduce(_ ++ _)
     case Inter(parts) => parts.iterator.map(_.alphabetBoundaries).reduce(_ ++ _)
@@ -124,7 +124,7 @@ enum Regex:
     case s: Regex.Star => s
     case _ => Regex.Star(this)
 
-  def * = star
+  def * : Regex = star
 
   /** Quantifier `this{n,m}` where m can be `Int.MaxValue` for unbounded. */
   def repeat(lo: Int, hi: Int): Regex =
@@ -228,7 +228,7 @@ object Regex:
  * constructor ([[CharSet.normalize]], [[CharSet.single]], [[CharSet.range]], [[CharSet.empty]],
  * [[CharSet.all]]); `complement` and `intersect` rely on that invariant.
  */
-final class CharSet @publicInBinary private[CharSet] (val ranges: Vector[Range]) extends AnyVal:
+final class CharSet @publicInBinary private[CharSet] (private val ranges: Vector[Range]) extends AnyVal:
 
   def contains(c: Int): Boolean =
     @tailrec
@@ -273,6 +273,8 @@ final class CharSet @publicInBinary private[CharSet] (val ranges: Vector[Range])
         loop(rs.tail, head.hi + 1, acc1)
     loop(ranges, 0, Vector.empty)
 
+  def iterator: Iterator[Range] = ranges.iterator
+
 object CharSet:
 
   /** Upper bound used for complement. Covers all valid Unicode code points. */
@@ -315,7 +317,24 @@ object CharSet:
     def apply(s: CharSet)(using Quotes): Expr[CharSet] =
       val rangeExprs: Seq[Expr[Range]] = s.ranges.map(Expr.apply)
       '{ CharSet(Vector(${ Varargs(rangeExprs) }*)) }
-  // $COVERAGE-ON$
+
+  given FromExpr[CharSet]:
+    private def fromRanges(exprs: Seq[Expr[Range]])(using Quotes) =
+      val ranges = exprs.foldLeft(Option(Vector.empty[Range])):
+        case (Some(acc), Expr(range)) => Some(acc :+ range)
+        case _ => None
+      ranges.map(new CharSet(_))
+
+    override def unapply(s: Expr[CharSet])(using Quotes): Option[CharSet] = s match
+      case '{ CharSet(Vector(${ Varargs(rangeExprs) }*)) } => fromRanges(rangeExprs)
+      case '{ new CharSet(Vector(${ Varargs(rangeExprs) }*)) } => fromRanges(rangeExprs)
+      case '{ CharSet.single(${ Expr(c) }: Char) } => Some(CharSet.single(c))
+      case '{ CharSet.single(${ Expr(c) }: Int) } => Some(CharSet.single(c))
+      case '{ CharSet.range(${ Expr(lo) }: Char, ${ Expr(hi) }: Char) } => Some(CharSet.range(lo, hi))
+      case '{ CharSet.range(${ Expr(lo) }: Int, ${ Expr(hi) }: Int) } => Some(CharSet.range(lo, hi))
+      case _ => None
+
+// $COVERAGE-ON$
 
 /** Single closed code-point range. */
 final case class Range(lo: Int, hi: Int):
@@ -329,6 +348,14 @@ object Range:
   given ToExpr[Range]:
     def apply(x: Range)(using Quotes): Expr[Range] =
       '{ Range(${ Expr(x.lo) }, ${ Expr(x.hi) }) }
+
+  given FromExpr[Range]:
+    override def unapply(x: Expr[Range])(using Quotes): Option[Range] = x match
+      case '{ Range(${ Expr(lo) }: Char, ${ Expr(hi) }: Char) } => Some(Range(lo, hi))
+      case '{ Range(${ Expr(lo) }: Int, ${ Expr(hi) }: Int) } => Some(Range(lo, hi))
+      case '{ new Range(${ Expr(lo) }: Char, ${ Expr(hi) }: Char) } => Some(Range(lo, hi))
+      case '{ new Range(${ Expr(lo) }: Int, ${ Expr(hi) }: Int) } => Some(Range(lo, hi))
+      case _ => None
   // $COVERAGE-ON$
 
 extension [A, CC[X] <: Iterable[X]](xs: scala.collection.IterableOps[A, CC, CC[A]])

--- a/test/CharSetTest.scala
+++ b/test/CharSetTest.scala
@@ -15,27 +15,27 @@ class CharSetTest extends munit.FunSuite:
     val a = CharSet.range('a', 'm')
     val b = CharSet.range('h', 'z')
     val u = a.union(b)
-    assertEquals(u.ranges, Vector(Range('a', 'z')))
+    assertEquals(u.iterator.toVector, Vector(Range('a', 'z')))
   }
 
   test("union keeps disjoint ranges separate") {
     val a = CharSet.range('a', 'c')
     val b = CharSet.range('x', 'z')
     val u = a.union(b)
-    assertEquals(u.ranges, Vector(Range('a', 'c'), Range('x', 'z')))
+    assertEquals(u.iterator.toVector, Vector(Range('a', 'c'), Range('x', 'z')))
   }
 
   test("union merges adjacent ranges") {
     val a = CharSet.range('a', 'c')
     val b = CharSet.range('d', 'f')
     val u = a.union(b)
-    assertEquals(u.ranges, Vector(Range('a', 'f')))
+    assertEquals(u.iterator.toVector, Vector(Range('a', 'f')))
   }
 
   test("intersect computes overlap") {
     val a = CharSet.range('a', 'm')
     val b = CharSet.range('h', 'z')
-    assertEquals(a.intersect(b).ranges, Vector(Range('h', 'm')))
+    assertEquals(a.intersect(b).iterator.toVector, Vector(Range('h', 'm')))
   }
 
   test("intersect of disjoint is empty") {
@@ -60,12 +60,12 @@ class CharSetTest extends munit.FunSuite:
 
   test("normalize merges overlapping and adjacent ranges") {
     val s = CharSet.normalize(Range('a', 'c'), Range('b', 'e'), Range('f', 'h'))
-    assertEquals(s.ranges, Vector(Range('a', 'h')))
+    assertEquals(s.iterator.toVector, Vector(Range('a', 'h')))
   }
 
   test("normalize sorts unsorted input") {
     val s = CharSet.normalize(Range('x', 'z'), Range('a', 'c'))
-    assertEquals(s.ranges, Vector(Range('a', 'c'), Range('x', 'z')))
+    assertEquals(s.iterator.toVector, Vector(Range('a', 'c'), Range('x', 'z')))
   }
 
   test("dotDefault excludes line terminators") {
@@ -139,7 +139,7 @@ class CharSetTest extends munit.FunSuite:
       Range('c', 'd'),
       Range('e', 'f'),
     )
-    assertEquals(s.ranges, Vector(Range('a', 'f')))
+    assertEquals(s.iterator.toVector, Vector(Range('a', 'f')))
   }
 
   test("normalize keeps non-overlapping ranges separate") {
@@ -149,7 +149,7 @@ class CharSetTest extends munit.FunSuite:
       Range('m', 'p'),
     )
     assertEquals(
-      s.ranges,
+      s.iterator.toVector,
       Vector(
         Range('a', 'c'),
         Range('f', 'h'),
@@ -160,7 +160,7 @@ class CharSetTest extends munit.FunSuite:
 
   test("normalize handles duplicate ranges") {
     val s = CharSet.normalize(Range('a', 'z'), Range('a', 'z'))
-    assertEquals(s.ranges, Vector(Range('a', 'z')))
+    assertEquals(s.iterator.toVector, Vector(Range('a', 'z')))
   }
 
   test("single from Int and Char agree") {


### PR DESCRIPTION
## Summary
- Makes `CharSet.ranges` private, exposing read access via a new `iterator: Iterator[Range]` instead — the field being a public `val` let callers reach past the normalizing API (`union`/`intersect`/`complement`/`normalize`) straight into the representation.
- Adds `FromExpr[CharSet]` and `FromExpr[Range]` alongside the existing `ToExpr` instances, so quoted `CharSet`/`Range` values can be pattern-matched back out of `Expr` in macro code.
- Updates the two call sites that read `.ranges` directly: `test/CharSetTest.scala` (now via `.iterator.toVector`) and `bench/CharSetBenchmark.scala` (moves a `.last.lo` lookup out of the `@Benchmark` hot path into `@Setup`, since it's no longer a free field read — and derives it from the benchmark's own `i * 4` construction formula rather than the library, so this file stays runnable against whatever's on `main` too, per how the CI benchmark-comparison job reuses it).
- Also gives `Regex.*` an explicit `: Regex` return type (was inferred).

Split out of #25 at the reviewer's request — that PR was doing too much at once (interpolator fix + this refactor + docs in one diff). This is the non-interpolator half; #25 now covers just the `regex"..."` fix and its tests.

## Test plan
- [x] `scala-cli test . --exclude "bench/**"` — 0 failed, 6 ignored (pre-existing TODOs)
- [x] `scala-cli --power fmt --check .` — clean
- [x] `scala-cli --power run --jmh . --exclude "test/**" -- CharSetBenchmark` compiles and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)