### PR TITLE
fix: union shorthand escapes (\d \s \w ...) nested inside a character class

### DIFF
--- a/regex/RegexParser.scala
+++ b/regex/RegexParser.scala
@@ -37,8 +37,6 @@ object RegexParseError:
  * Known gaps relative to `java.util.regex.Pattern` (tracked, not yet implemented):
  *   - in-class intersection `[a-z&&[^g-p]]` is silently misparsed as literal chars instead of
  *     being rejected or computing the intersection
- *   - shorthand classes nested inside a character class, e.g. `[\d.]`, are rejected outright
- *     instead of being unioned into the class like Java does
  */
 object RegexParser:
 
@@ -221,32 +219,41 @@ object RegexParser:
       expect('[')
       val negated = !eof && cur == '^'
       if negated then pos += 1
-      @tailrec def loop(acc: Vector[Range]): Vector[Range] =
+      // A shorthand class item (\d, \s, \w, ...) contributes to `shorthand` directly and can't
+      // start or end a `-` range, matching Java: `[\d-z]` is digit, '-', and 'z' as three
+      // separate members (the dash just isn't treated as a range operator there), while
+      // `[a-\d]` is a syntax error (no single code point to range up to).
+      @tailrec def loop(ranges: Vector[Range], shorthand: CharSet): (Vector[Range], CharSet) =
         if !eof && cur != ']' then
-          val lo = readClassChar()
-          val hi =
-            if !eof && cur == '-' && pos + 1 < src.length && src.charAt(pos + 1) != ']' then
-              pos += 1
-              readClassChar()
-            else lo
-          if hi < lo then fail(s"invalid character-class range `${lo.toChar}-${hi.toChar}`: end must be >= start")
-          loop(acc :+ Range(lo, hi))
-        else acc
-      val ranges = loop(Vector.empty)
+          readClassChar() match
+            case Left(set) => loop(ranges, shorthand.union(set))
+            case Right(lo) =>
+              val hi =
+                if !eof && cur == '-' && pos + 1 < src.length && src.charAt(pos + 1) != ']' then
+                  pos += 1
+                  readClassChar() match
+                    case Left(_) => fail(s"invalid character-class range: shorthand escape can't end a range")
+                    case Right(hi) => hi
+                else lo
+              if hi < lo then fail(s"invalid character-class range `${lo.toChar}-${hi.toChar}`: end must be >= start")
+              loop(ranges :+ Range(lo, hi), shorthand)
+        else (ranges, shorthand)
+      val (ranges, shorthand) = loop(Vector.empty, CharSet.empty)
       expect(']')
-      if ranges.isEmpty then fail("empty character class")
-      val set = CharSet.normalize(ranges)
+      if ranges.isEmpty && shorthand.isEmpty then fail("empty character class")
+      // Skips the union (and the second normalizing pass it implies) in the common case where
+      // the class has no shorthand escape at all, matching what this did before they existed.
+      val set = if shorthand.isEmpty then CharSet.normalize(ranges) else CharSet.normalize(ranges).union(shorthand)
       val finalSet = if negated then set.complement else set
       Regex(finalSet)
 
-    private def readClassChar(): Int =
+    private def readClassChar(): Either[CharSet, Int] =
       if eof then fail("unterminated character class")
       (cur: @switch) match
         case '\\' =>
           pos += 1
-          readEscapedChar(inClass = true).getOrElse:
-            fail("shorthand escapes (\\d, \\s, \\w, ...) are not supported inside character classes")
-        case _ => consume().toInt
+          readEscapedChar(inClass = true)
+        case _ => Right(consume().toInt)
 
     private def parseEscape(): Regex =
       expect('\\')

--- a/test/RegexConformanceTest.scala
+++ b/test/RegexConformanceTest.scala
@@ -239,11 +239,7 @@ class RegexConformanceTest extends munit.FunSuite:
     assert(equiv("\\s", "[ \\t\\n\\r\\f\\x{B}]"))
   }
 
-  test(
-    ("dregex: shorthand classes nested inside a character class, e.g. `[\\d]` (testShortcutCharacterClasses)" +
-      " - TODO: not supported; readClassChar rejects \\d/\\s/\\w/... inside `[...]` outright," +
-      " unlike Java which allows and unions them").ignore,
-  ) {
+  test("dregex: shorthand classes nested inside a character class, e.g. `[\\d]` (testShortcutCharacterClasses)") {
     assert(equiv("\\d", "[\\d]"))
   }
 

--- a/test/RegexParserTest.scala
+++ b/test/RegexParserTest.scala
@@ -157,6 +157,33 @@ class RegexParserTest extends munit.FunSuite:
     )
   }
 
+  test("unions a shorthand escape into a character class") {
+    assertEquals(parse("[\\d]"), Regex(CharSet.range('0', '9')))
+    assertEquals(
+      parse("[\\da-f]"),
+      Regex(CharSet.range('0', '9').union(CharSet.normalize(Range('a', 'f')))),
+    )
+  }
+
+  test("unions a negated shorthand escape into a character class") {
+    assertEquals(parse("[\\D]"), Regex(CharSet.range('0', '9').complement))
+  }
+
+  test("negates the union of a mixed character class") {
+    assertEquals(parse("[^\\da-f]"), Regex(CharSet.range('0', '9').union(CharSet.normalize(Range('a', 'f'))).complement))
+  }
+
+  test("a shorthand escape can't start a range, but a following `-` is a literal member") {
+    assertEquals(
+      parse("[\\d-z]"),
+      Regex(CharSet.range('0', '9').union(CharSet.normalize(Range('-', '-'), Range('z', 'z')))),
+    )
+  }
+
+  test("rejects a shorthand escape ending a range") {
+    assertInvalidSyntax(RegexParser.parse("[a-\\d]"))
+  }
+
   test("parses \\s and \\w shorthands") {
     assertEquals(
       parse("\\s"),


### PR DESCRIPTION
## Summary
Closes #23.

`readClassChar` rejected `\d`/`\s`/`\w`/... outright inside `[...]`, unlike Java which unions them into the class (e.g. `[\da-f]` = digit or a-f). `readEscapedChar` already returned `Either[CharSet, Int]` to support exactly this; the character-class loop just discarded the `Left` case with a hard failure instead of unioning it.

- `[\d]`, `[\da-f]`, `[\D]`, `[^\da-f]` now parse and union correctly.
- Matches Java's edge-case handling: a shorthand escape can't start or end a `-` range — `[\d-z]` is digit ∪ `-` ∪ `z` (three separate members, dash isn't a range operator there), while `[a-\d]` is rejected as invalid syntax (no single code point to range up to).
- Un-ignores the matching `RegexConformanceTest` case, updates `RegexParser`'s doc comment (this was listed as a known gap), and adds direct coverage in `RegexParserTest`.

Also fixes a real perf regression the union introduced: unioning with the (usually empty) shorthand set unconditionally re-normalized an already-normalized `CharSet` on every character class, even ones with no shorthand escapes at all. Caught by the local before/after benchmark comparison this repo's CI does for every PR — `RegexBenchmark.parse` (which parses a pattern containing two character classes) had regressed 11-30% before this fix, back within noise after. Skips the redundant normalize when there's nothing to union in.

## Test plan
- [x] `scala-cli test . --exclude "bench/**"` — 0 failed, 5 ignored (was 6 — this ticket's case now runs and passes)
- [x] `scala-cli --power fmt --check .` — clean
- [x] `scala-cli --power run --jmh . --exclude "test/**" -- RegexBenchmark.parse`, compared against `main` locally: within noise (-12% to +2.5%, no consistent direction) after the normalize fix, vs. a consistent +11% to +30% regression before it

🤖 Generated with [Claude Code](https://claude.com/claude-code)