### PR TITLE
fix: implement in-class && intersection instead of silently misparsing it

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,4 @@ back to parsing at runtime and throws `IllegalArgumentException` on failure inst
 ## Status
 
 Early (`0.x`). The parser deliberately supports a subset of `java.util.regex.Pattern`'s syntax —
-see the package scaladoc for exactly what's in and what's out, including a couple of known gaps
-(in-class `&&` intersection, shorthand classes nested inside `[...]`) tracked as ignored tests
-with a `TODO`.
+see the package scaladoc for exactly what's in and what's out.

--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -49,9 +49,10 @@ private def regexInterpolatorImpl(scExpr: Expr[StringContext])(using quotes: Quo
  * generated `unapply` methods is allowed.
  *
  * Supports literals, escapes (\d \D \s \S \w \W \t \n \r \f \a \e \v \cX \0[n[n]] \xhh
- * \x{h...h} \uhhhh \Q...\E \R and meta-escapes), character classes (including ranges and
- * negation), `.`, alternation `|`, non-capturing-style groups `(...)`, quantifiers `*` `+`
- * `?` `{n}` `{n,}` `{n,m}` (bounds capped at [[Regex.maxRepeatBound]]).
+ * \x{h...h} \uhhhh \Q...\E \R and meta-escapes), character classes (including ranges, negation,
+ * nested subclasses, and `&&` intersection), `.`, alternation `|`, non-capturing-style groups
+ * `(...)`, quantifiers `*` `+` `?` `{n}` `{n,}` `{n,m}` (bounds capped at
+ * [[Regex.maxRepeatBound]]).
  *
  * Unsupported (parser returns [[RegexParseError.UnsupportedFeature]]):
  * anchors `^` `$` `\b` `\B` `\A` `\Z` `\z` `\G`, lookaround `(?=` `(?!` `(?<=` `(?<!`,

--- a/regex/RegexParser.scala
+++ b/regex/RegexParser.scala
@@ -24,8 +24,9 @@ object RegexParseError:
  *
  * Supported subset (see [[Regex]] doc): literals, escapes (\d \D \s \S \w \W \t \n \r \f
  * \a \e \v \cX \0[n[n]] \xhh \x{h...h} \uhhhh \Q...\E \R and meta-escapes \. \* \+ \? \(
- * \) \[ \] \{ \} \| \^ \$ \-), `.`, char classes `[...]` `[^...]` with ranges (`\b` inside
- * a class means backspace, matching Java), alternation `|`, groups `(...)` (capturing or
+ * \) \[ \] \{ \} \| \^ \$ \-), `.`, char classes `[...]` `[^...]` with ranges, nested shorthand
+ * escapes (`[\da-f]`), nested subclasses, and `&&` intersection (`[a-z&&[^aeiou]]`) (`\b`
+ * inside a class means backspace, matching Java), alternation `|`, groups `(...)` (capturing or
  * `(?:...)`, flag groups are NOT supported), quantifiers `*` `+` `?` `{n}` `{n,}` `{n,m}`
  * (bounds capped at [[Regex.maxRepeatBound]]).
  *
@@ -33,10 +34,6 @@ object RegexParseError:
  * `\1`..`\9` `\k<name>` `\g{...}`, Unicode properties `\p{...}`, grapheme clusters `\X`,
  * named groups, flag groups. Any other undefined letter escape (e.g. `\m`, `\y`, `\q`) is
  * rejected as invalid syntax, matching `java.util.regex.Pattern`'s own behavior.
- *
- * Known gaps relative to `java.util.regex.Pattern` (tracked, not yet implemented):
- *   - in-class intersection `[a-z&&[^g-p]]` is silently misparsed as literal chars instead of
- *     being rejected or computing the intersection
  */
 object RegexParser:
 
@@ -215,37 +212,70 @@ object RegexParser:
           else unsupported("named group")
         case _ => unsupported("flag group")
 
-    private def parseCharClass(): Regex =
+    private def parseCharClass(): Regex = Regex(parseClassBody())
+
+    /** True at a `&&` intersection operator; a lone `&` is just a literal member. */
+    private def atIntersectionOp: Boolean = !eof && cur == '&' && pos + 1 < src.length && src.charAt(pos + 1) == '&'
+
+    /**
+     * `[...]`, from the opening `[` through its matching `]` — used both for the top-level
+     * class atom and, recursively, for `[nested]` subclasses on either side of `&&`
+     * (`[a-z&&[^bc]]`). Each side of `&&` is independently negatable.
+     */
+    private def parseClassBody(): CharSet =
       expect('[')
       val negated = !eof && cur == '^'
       if negated then pos += 1
-      // A shorthand class item (\d, \s, \w, ...) contributes to `shorthand` directly and can't
-      // start or end a `-` range, matching Java: `[\d-z]` is digit, '-', and 'z' as three
-      // separate members (the dash just isn't treated as a range operator there), while
-      // `[a-\d]` is a syntax error (no single code point to range up to).
-      @tailrec def loop(ranges: Vector[Range], shorthand: CharSet): (Vector[Range], CharSet) =
-        if !eof && cur != ']' then
-          readClassChar() match
-            case Left(set) => loop(ranges, shorthand.union(set))
-            case Right(lo) =>
-              val hi =
-                if !eof && cur == '-' && pos + 1 < src.length && src.charAt(pos + 1) != ']' then
-                  pos += 1
-                  readClassChar() match
-                    case Left(_) => fail(s"invalid character-class range: shorthand escape can't end a range")
-                    case Right(hi) => hi
-                else lo
-              if hi < lo then fail(s"invalid character-class range `${lo.toChar}-${hi.toChar}`: end must be >= start")
-              loop(ranges :+ Range(lo, hi), shorthand)
-        else (ranges, shorthand)
-      val (ranges, shorthand) = loop(Vector.empty, CharSet.empty)
+      val set = parseClassIntersection()
       expect(']')
-      if ranges.isEmpty && shorthand.isEmpty then fail("empty character class")
+      if negated then set.complement else set
+
+    /** intersection = union ('&&' union)* */
+    private def parseClassIntersection(): CharSet =
+      @tailrec def loop(acc: CharSet): CharSet =
+        if atIntersectionOp then
+          pos += 2
+          loop(acc.intersect(parseClassUnion()))
+        else acc
+      loop(parseClassUnion())
+
+    /**
+     * union = (range | shorthandEscape | `[nested]`)*, stopping at `]` or `&&`. A shorthand
+     * class item (`\d`, `\s`, `\w`, ...) contributes to `shorthand` directly and can't start or
+     * end a `-` range, matching Java: `[\d-z]` is digit, '-', and 'z' as three separate members
+     * (the dash just isn't treated as a range operator there), while `[a-\d]` is a syntax error
+     * (no single code point to range up to). Likewise a `-` immediately before `&&` is a
+     * literal trailing dash rather than the start of a range.
+     */
+    private def parseClassUnion(): CharSet =
+      @tailrec def loop(ranges: Vector[Range], extra: CharSet): (Vector[Range], CharSet) =
+        if !eof && cur != ']' && !atIntersectionOp then
+          if cur == '[' then loop(ranges, extra.union(parseClassBody()))
+          else
+            readClassChar() match
+              case Left(set) => loop(ranges, extra.union(set))
+              case Right(lo) =>
+                val hi =
+                  if !eof && cur == '-' && pos + 1 < src.length && src.charAt(pos + 1) != ']' && !atIntersectionOpAt(
+                      pos + 1,
+                    )
+                  then
+                    pos += 1
+                    readClassChar() match
+                      case Left(_) => fail(s"invalid character-class range: shorthand escape can't end a range")
+                      case Right(hi) => hi
+                  else lo
+                if hi < lo then fail(s"invalid character-class range `${lo.toChar}-${hi.toChar}`: end must be >= start")
+                loop(ranges :+ Range(lo, hi), extra)
+        else (ranges, extra)
+      val (ranges, extra) = loop(Vector.empty, CharSet.empty)
+      if ranges.isEmpty && extra.isEmpty then fail("empty character class")
       // Skips the union (and the second normalizing pass it implies) in the common case where
-      // the class has no shorthand escape at all, matching what this did before they existed.
-      val set = if shorthand.isEmpty then CharSet.normalize(ranges) else CharSet.normalize(ranges).union(shorthand)
-      val finalSet = if negated then set.complement else set
-      Regex(finalSet)
+      // this operand has no shorthand escape or nested subclass at all.
+      if extra.isEmpty then CharSet.normalize(ranges) else CharSet.normalize(ranges).union(extra)
+
+    private def atIntersectionOpAt(p: Int): Boolean = p < src.length && src.charAt(p) == '&' && p + 1 < src.length &&
+      src.charAt(p + 1) == '&'
 
     private def readClassChar(): Either[CharSet, Int] =
       if eof then fail("unterminated character class")

--- a/test/RegexConformanceTest.scala
+++ b/test/RegexConformanceTest.scala
@@ -7,9 +7,9 @@ package halotukozak.regex
  * original test code itself.
  *
  * Cases exercising features this engine intentionally doesn't support (POSIX/Unicode property
- * classes, lookaround, backreferences, named groups, in-class `&&` intersection, or a
- * Matcher-style find/replace/split API this engine never had) are `ignore`d with a `TODO`
- * rather than deleted, so the gap stays visible instead of silently disappearing.
+ * classes, lookaround, backreferences, named groups, or a Matcher-style find/replace/split API
+ * this engine never had) are `ignore`d with a `TODO` rather than deleted, so the gap stays
+ * visible instead of silently disappearing.
  */
 class RegexConformanceTest extends munit.FunSuite:
 
@@ -118,11 +118,7 @@ class RegexConformanceTest extends munit.FunSuite:
     assertInvalidSyntax(RegexParser.parse(".{4294967296}"))
   }
 
-  test(
-    ("jdk: in-class intersection `[a&&b]` (droppedClassesWithIntersection)" +
-      " - TODO: not supported; `&&` is currently silently misparsed as literal chars instead of" +
-      " being rejected or computing the intersection").ignore,
-  ) {
+  test("jdk: in-class intersection `[a&&b]` (droppedClassesWithIntersection)") {
     assertEquals(parse("[A-Z&&[A-Z]0-9]"), Regex.range('A', 'Z'))
   }
 

--- a/test/RegexParserTest.scala
+++ b/test/RegexParserTest.scala
@@ -184,6 +184,33 @@ class RegexParserTest extends munit.FunSuite:
     assertInvalidSyntax(RegexParser.parse("[a-\\d]"))
   }
 
+  test("computes in-class && intersection") {
+    assertEquals(parse("[a-z&&[def]]"), Regex(CharSet.normalize(Range('d', 'f'))))
+  }
+
+  test("computes in-class && subtraction via negated nested subclass") {
+    assertEquals(
+      parse("[a-z&&[^bc]]"),
+      Regex(CharSet.range('a', 'z').intersect(CharSet.normalize(Range('b', 'c')).complement)),
+    )
+  }
+
+  test("chains multiple && intersections") {
+    assertEquals(parse("[a-z&&[^m-p]&&[^a-c]]"), parse("[d-lq-z]"))
+  }
+
+  test("unions a nested subclass alongside plain members") {
+    assertEquals(parse("[0-9[a-f]]"), Regex(CharSet.normalize(Range('0', '9'), Range('a', 'f'))))
+  }
+
+  test("a lone `&` is a literal member, not an intersection operator") {
+    assertEquals(parse("[a&b]"), Regex(CharSet.normalize(Range('&', '&'), Range('a', 'a'), Range('b', 'b'))))
+  }
+
+  test("rejects an empty && operand") {
+    assertInvalidSyntax(RegexParser.parse("[a-z&&]"))
+  }
+
   test("parses \\s and \\w shorthands") {
     assertEquals(
       parse("\\s"),


### PR DESCRIPTION
## Summary
Closes #24.

Stacked on #27 (ticket #23) — same function (`parseCharClass`), so this builds on that rewrite rather than redoing it. Base will retarget to `main` automatically once #27 merges.

`[a&&b]` was silently misparsed as literal chars `a`, `&`, `&`, `b` instead of being rejected or computing the intersection. `CharSet` already had `intersect`; this is purely parser wiring, as the ticket predicted.

Restructures character-class parsing into three layers mirroring Java's own grammar:
- `parseClassBody` — the `[...]` atom, independently negatable, used both at top level and recursively for `[nested]` subclasses
- `parseClassIntersection` — `union ('&&' union)*`
- `parseClassUnion` — ranges, shorthand escapes, and nested `[...]` subclasses, unioned together

Handles Java's edge cases:
- a lone `&` is a literal member, not an operator (`[a&b]`)
- `[a-z&&]` (empty operand) is invalid syntax
- intersection chains (`[a-z&&[^m-p]&&[^a-c]]`)
- subtraction via a negated nested subclass (`[a-z&&[^bc]]`)

Un-ignores the matching `RegexConformanceTest` case (verified the tricky `[A-Z&&[A-Z]0-9]` example by hand: `(A-Z) ∩ ((A-Z) ∪ (0-9)) = A-Z`), updates doc comments that listed this as a known gap, and adds direct parser coverage.

## Test plan
- [x] `scala-cli test . --exclude "bench/**"` — 0 failed, 4 ignored (was 6 originally, 5 after #27 — this ticket's case now runs and passes)
- [x] `scala-cli --power fmt --check .` — clean
- [x] `scala-cli --power run --jmh . --exclude "test/**" -- RegexBenchmark.parse`, compared against `main` locally twice: within noise both times (-3.4% to +1.5%, and -0.1% to +10.6% — that one 🔴 didn't reproduce on rerun, all three params measure the identical fixed pattern so an inconsistent single-param hit is noise, not a real regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)