### PR TITLE
fix: give RegexParseError a readable toString instead of a raw field dump

### DIFF
--- a/regex/RegexParser.scala
+++ b/regex/RegexParser.scala
@@ -10,6 +10,14 @@ sealed trait RegexParseError:
   def position: Int
   def message: String
 
+  /**
+   * Overridden here (rather than left to each case class) so it's picked up by every case
+   * class's synthesized `toString` slot instead of the default field dump they'd otherwise
+   * generate (`InvalidSyntax((abc,3,expected \`)\` at position 3)`) — callers that just
+   * interpolate the error value directly get a readable message "for free".
+   */
+  override def toString: String = s"""$message (at position $position in "$pattern")"""
+
 object RegexParseError:
 
   /** Pattern is syntactically malformed (unterminated group, dangling backslash, etc.). */

--- a/test/RegexInterpolatorTest.scala
+++ b/test/RegexInterpolatorTest.scala
@@ -77,7 +77,9 @@ class RegexInterpolatorTest extends munit.FunSuite:
     val errors = typeCheckErrors("""_root_.scala.StringContext("(?=foo)").regex()""")
     assertEquals(errors.size, 1)
     assert(
-      errors.head.message.contains("Regex parse error") && errors.head.message.contains("UnsupportedFeature"),
+      errors.head.message.contains("Regex parse error") &&
+        errors.head.message.contains("unsupported regex feature `lookahead`") &&
+        errors.head.message.contains("at position 2") && errors.head.message.contains(""""(?=foo)""""),
       s"unexpected message: ${errors.head.message}",
     )
   }
@@ -86,7 +88,8 @@ class RegexInterpolatorTest extends munit.FunSuite:
     val errors = typeCheckErrors("""_root_.scala.StringContext("(").regex()""")
     assertEquals(errors.size, 1)
     assert(
-      errors.head.message.contains("Regex parse error") && errors.head.message.contains("InvalidSyntax"),
+      errors.head.message.contains("Regex parse error") && errors.head.message.contains("at position 1") &&
+        errors.head.message.contains(""""(""""),
       s"unexpected message: ${errors.head.message}",
     )
   }

--- a/test/RegexParserTest.scala
+++ b/test/RegexParserTest.scala
@@ -16,6 +16,14 @@ class RegexParserTest extends munit.FunSuite:
     case Left(_: RegexParseError.UnsupportedFeature) => ()
     case other => fail(s"expected UnsupportedFeature, got $other")
 
+  test("RegexParseError's toString includes the message, position, and pattern") {
+    val err: RegexParseError = RegexParser.parse("(?=foo)").left.getOrElse(fail("expected a parse error"))
+    val text = err.toString
+    assert(text.contains("unsupported regex feature `lookahead`"), text)
+    assert(text.contains("at position 2"), text)
+    assert(text.contains("\"(?=foo)\""), text)
+  }
+
   test("parses literal string") {
     assertEquals(parse("abc"), Regex.literal("abc"))
   }


### PR DESCRIPTION
## Summary
Both places that build a user-facing message from a `RegexParseError` (`regex"..."`'s compile-time `report.errorAndAbort` and its runtime `IllegalArgumentException`) interpolated the error value directly — `s"Regex parse error: \$error"` — which called the case classes' synthesized `toString` and produced e.g. `UnsupportedFeature((?=foo),2,lookahead)`, exposing constructor/field order instead of anything meant to be read.

Overrides `toString` on the `RegexParseError` trait itself, so every error — wherever it gets interpolated, not just those two sites — now reads as:
```
unsupported regex feature `lookahead` (at position 2 in "(?=foo)")
```
Verified this actually suppresses each case class's own synthesized `toString` (a case class only generates one when it doesn't already inherit a concrete definition — confirmed this empirically before relying on it).

**On making `RegexParseError` extend `RuntimeException`:** considered it, decided against it. It's the value type `RegexParser.parse` returns via `Either` for its primary (non-throwing) API — making it a `Throwable` would mean paying stack-trace-capture cost on every construction, even for values that are only ever pattern-matched and never thrown. The two places that *do* need to throw already do (wrapped in `IllegalArgumentException`), which is now what actually gets a good message out of this fix.

## Test plan
- [x] `scala-cli test . --exclude "bench/**"` — 0 failed, 4 ignored (pre-existing TODOs)
- [x] `scala-cli --power fmt --check .` — clean
- [x] Added a direct test asserting the formatted `toString`, and updated the two interpolator tests that were (accidentally) asserting on the old ugly output

🤖 Generated with [Claude Code](https://claude.com/claude-code)