### PR TITLE
Fix stale doc comment in CharSetBenchmark.scala

### DIFF
--- a/bench/CharSetBenchmark.scala
+++ b/bench/CharSetBenchmark.scala
@@ -6,9 +6,9 @@ import java.util.concurrent.TimeUnit
 import scala.compiletime.uninitialized
 
 /**
- * `CharSet.contains` currently does a linear scan over sorted, non-overlapping ranges — a
- * candidate for a binary search. `rangeCount` lets that (and the other set operations) be
- * measured across input sizes instead of at one fixed point.
+ * `CharSet.contains` does a binary search over sorted, non-overlapping ranges, backed by an
+ * array-based `ArraySeq` for true O(1) indexed access. `rangeCount` lets that (and the other
+ * set operations) be measured across input sizes instead of at one fixed point.
  *
  * Run: `scala-cli run --jmh . -- CharSetBenchmark` (see `bench/README.md`).
  */


### PR DESCRIPTION
## Summary
- `bench/CharSetBenchmark.scala`'s doc comment claimed `contains()` "currently does a linear scan ... a candidate for a binary search," but the implementation has been a binary search for a while - the comment just never got updated.
- Rewords the comment to describe what the benchmark actually measures now.

Closes #36.

**Stacked on #39** (`fix/charset-arrayseq-backing`): the reworded comment mentions the `ArraySeq`-backed storage that PR introduces, so this is based on that branch rather than `main`. Base should be retargeted to `main` once #39 merges (or GitHub will do it automatically).

## Test plan
- [x] `scala-cli --power fmt --check .`
- [x] Doc-only change to a bench-only file; no behavior change.