### PR TITLE
Add JMH benchmark coverage for TokenMatcher

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -2,7 +2,8 @@
 
 JMH microbenchmarks for the hot paths of this library: `Regex` construction (`alt`/`concat`/
 `repeat`, which drive `Set`-based ACI normalization and `hashCode`), the Brzozowski-derivative
-machinery in `Subset` (`subset`/`isEmpty`/`derive`), and `CharSet.contains`.
+machinery in `Subset` (`subset`/`isEmpty`/`derive`), `CharSet.contains`, and the compiled
+`TokenMatcher` DFA (`matchAt`/`findFirst`/`compile`).
 
 This directory only compiles under `--jmh` — it's excluded (`--exclude "bench/**"`) from every
 other `scala-cli` invocation (`compile`, `test`, `doc`, `publish`) because `@Benchmark` needs

--- a/bench/TokenMatcherBenchmark.scala
+++ b/bench/TokenMatcherBenchmark.scala
@@ -1,0 +1,65 @@
+package halotukozak.regex
+
+import org.openjdk.jmh.annotations.*
+
+import java.util.concurrent.TimeUnit
+import scala.compiletime.uninitialized
+
+/**
+ * Matching-side benchmarks for [[TokenMatcher]] — the array-lookup DFA that `RegexBenchmark`
+ * (construction) and `SubsetBenchmark` (derivative exploration) don't cover. `matchAt`/
+ * `findFirst` are the actual hot path documented on `TokenMatcher`: no `Regex`/`Subset`
+ * allocation or derivation once `compile` has run, just a binary search over `boundaries`
+ * plus an `Int` transition-table read per code point. `compile` itself (DFA construction via
+ * Brzozowski derivatives over all patterns in parallel) is included separately since it's a
+ * one-time cost with very different scaling behavior from the steady-state lookups.
+ *
+ * Run: `scala-cli run --jmh . -- TokenMatcherBenchmark` (see `bench/README.md`).
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+class TokenMatcherBenchmark:
+
+  private def parse(pattern: String): Regex = RegexParser.parse(pattern).toOption.get
+
+  // A small realistic lexer: keyword literals racing against a generic identifier rule, plus
+  // numeric and whitespace tokens - the same shape as TokenMatcherTest's "real lexer" cases.
+  private val lexerPatterns =
+    Seq("if", "else", "while", "return", "[a-zA-Z_][a-zA-Z0-9_]*", "[0-9]+(\\.[0-9]+)?", "[ \\t\\n]+")
+
+  private val lexer: TokenMatcher = TokenMatcher.fromRegexes(lexerPatterns.map(parse)*)
+
+  @Param(Array("10", "100", "1000"))
+  var length: Int = uninitialized
+
+  private var identifierInput: String = uninitialized
+  private var sourceInput: String = uninitialized
+
+  @Setup(Level.Trial)
+  def setup(): Unit =
+    // Worst case for matchAt: a single long identifier, so the DFA walks `length` transitions
+    // before hitting the dead state (end of input) rather than bailing out after a few chars.
+    identifierInput = "_" + Iterator.continually('a' to 'z').flatten.take(length - 1).mkString
+    // A source-like string of space-separated keywords/identifiers/numbers, for findFirst to
+    // scan across many tokens instead of matching once at position 0.
+    val tokens = Seq("if", "x1", "42", "return", "while", "y_2", "3.14", "else")
+    sourceInput = Iterator.continually(tokens).flatten.take(length).mkString(" ")
+
+  /** Steady-state lookup cost: one long identifier, no dead transitions until EOF. */
+  @Benchmark
+  def matchAtIdentifier(): Option[(priority: Int, end: Int)] = lexer.matchAt(identifierInput, 0)
+
+  /** Scans a whole token stream, exercising `findFirst`'s skip-then-match loop. */
+  @Benchmark
+  def findFirstAcrossSource(): Int =
+    @annotation.tailrec
+    def loop(from: Int, count: Int): Int =
+      lexer.findFirst(sourceInput, from) match
+        case Some((_, _, end)) => loop(end, count + 1)
+        case None => count
+    loop(0, 0)
+
+  /** One-time DFA-construction cost, scaling with the number of racing patterns. */
+  @Benchmark
+  def compileLexer(): TokenMatcher = TokenMatcher.fromRegexes(lexerPatterns.map(parse)*)


### PR DESCRIPTION
## Summary
- `RegexBenchmark` covers construction and `SubsetBenchmark` covers Brzozowski-derivative exploration, but nothing measured `TokenMatcher` - the array-lookup DFA that's the library's actual steady-state hot path once a matcher is compiled (per its own doc comment: no `Regex`/`Subset` allocation or derivation on that path, just a binary search + table read).
- Adds `bench/TokenMatcherBenchmark.scala`:
  - `matchAtIdentifier` - steady-state lookup cost over one long identifier (no dead transitions until EOF).
  - `findFirstAcrossSource` - `findFirst`'s skip-then-match loop over a token stream.
  - `compileLexer` - one-time DFA-construction cost.
  - Against a small realistic lexer (keyword literals racing a generic identifier rule, numbers, whitespace), same shape as `TokenMatcherTest`'s real-lexer cases.
- Updates `bench/README.md` to mention the new benchmark class.

## Test plan
- [x] `scala-cli compile --jmh . --exclude "test/**"`
- [x] `scala-cli run --jmh . --exclude "test/**" -- TokenMatcherBenchmark -f 1 -wi 1 -i 1 -w 200ms -r 200ms` - runs cleanly, timings scale linearly with input length as expected
- [x] `scala-cli --power fmt --check .`