### PR TITLE
ci: cache scala-cli/Bloop incremental build state across jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,13 @@ jobs:
           fetch-depth: 0
       - name: Setup coursier cache
         uses: coursier/cache-action@v8.1
+      - name: Cache scala-cli/Bloop incremental build
+        uses: actions/cache@v4
+        with:
+          path: .scala-build
+          key: scala-build-jvm-${{ hashFiles('project.scala', '**/*.scala') }}
+          restore-keys: |
+            scala-build-jvm-
       - uses: VirtusLab/scala-cli-setup@v1
       - name: Run tests
         # Coverage is recorded only for production sources; tests were previously
@@ -62,6 +69,13 @@ jobs:
       - uses: actions/checkout@v7
       - name: Setup coursier cache
         uses: coursier/cache-action@v8.1
+      - name: Cache scala-cli/Bloop incremental build
+        uses: actions/cache@v4
+        with:
+          path: .scala-build
+          key: scala-build-${{ matrix.platform }}-${{ hashFiles('project.scala', '**/*.scala') }}
+          restore-keys: |
+            scala-build-${{ matrix.platform }}-
       - uses: VirtusLab/scala-cli-setup@v1
       - name: Compile
         run: scala-cli --power compile . --exclude "bench/**" --platform ${{ matrix.platform }} ${{ matrix.args }}
@@ -83,6 +97,13 @@ jobs:
       - uses: actions/checkout@v7
       - name: Setup coursier cache
         uses: coursier/cache-action@v8.1
+      - name: Cache scala-cli/Bloop incremental build
+        uses: actions/cache@v4
+        with:
+          path: .scala-build
+          key: scala-build-${{ matrix.platform }}-${{ hashFiles('project.scala', '**/*.scala') }}
+          restore-keys: |
+            scala-build-${{ matrix.platform }}-
       - uses: VirtusLab/scala-cli-setup@v1
       - name: Run tests
         run: scala-cli --power test . --exclude "bench/**" --platform ${{ matrix.platform }} ${{ matrix.args }}


### PR DESCRIPTION
## Summary
`test`, `compile` (matrix: jvm/scala-js/scala-native), and `test-cross-platform` (matrix: scala-js/scala-native) each started from a clean checkout and recompiled the whole project from scratch every run - only the Coursier *dependency* cache was shared (`coursier/cache-action`), not scala-cli/Bloop's *incremental compilation* state.

- Adds an `actions/cache@v4` step to those jobs, caching `.scala-build` (where scala-cli/Bloop keep generated project config plus incremental classfiles/analysis - already `.gitignore`d as a build artifact directory).
- Key: `scala-build-<platform>-<hash of project.scala + all .scala sources>`, with a `scala-build-<platform>-` restore-key fallback so a PR that only touches a few files still warm-starts Bloop's incremental compiler from the closest prior cache instead of building from nothing.
- `jvm` keys are intentionally shared between the `test` job and the `compile` matrix's `jvm` leg (same for `scala-js`/`scala-native` between `compile` and `test-cross-platform`), since both sides compile overlapping sources into the same `.scala-build` tree - pooling is a net win even though a concurrent write to the same key from parallel jobs means only one "wins" that particular save (harmless).

Closes #38.

## Out of scope (by design)
- `lint` - scalafmt only, no compilation.
- `benchmark` - deliberately noisy/informational per its own comment, and its `main` baseline builds in a separate `git worktree` outside this repo, which would need a different caching approach. Happy to follow up separately if wanted.

## Test plan
- [x] Validated YAML with `ruby -ryaml` (`YAML.load_file`)
- [ ] First run on this PR will be a cold cache (as expected); a same-platform follow-up push should show a warm restore in the Actions log