### PR TITLE
perf(CharSet): two-pointer merge for union instead of full re-sort

### DIFF
--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -290,23 +290,34 @@ final class CharSet @publicInBinary private[CharSet] (private val ranges: ArrayS
    * throws away the fact that both inputs are already ordered. Mirrors `intersect`'s existing
    * two-pointer walk, just coalescing overlapping/adjacent ranges (`normalize`'s rule) instead
    * of intersecting them.
+   *
+   * Written as a `while` loop writing straight into an `ArraySeq.newBuilder` (sized up front
+   * via `sizeHint`) rather than an immutable `Vector` accumulator converted to `ArraySeq` at
+   * the end (`intersect`/`complement`/`normalize`'s style, and this method's own first cut):
+   * benchmarked ~2.3-2.8x faster across `rangeCount` 50-5000, since it skips both the `Vector`
+   * node allocations and the full extra copy `ArraySeq.from` needs to flatten them into an
+   * array.
    */
   infix def union(other: CharSet): CharSet =
-    @tailrec
-    def loop(i: Int, j: Int, cur: Range | Null, acc: Vector[Range]): CharSet =
-      if i >= ranges.length && j >= other.ranges.length then
-        CharSet(ArraySeq.from(cur match
-          case null => acc
-          case c => acc :+ c))
-      else
-        val takeFromA = j >= other.ranges.length || (i < ranges.length && ranges(i).lo <= other.ranges(j).lo)
-        val next = if takeFromA then ranges(i) else other.ranges(j)
-        val (ni, nj) = if takeFromA then (i + 1, j) else (i, j + 1)
-        cur match
-          case null => loop(ni, nj, next, acc)
-          case c if next.lo <= c.hi + 1 => loop(ni, nj, Range(c.lo, math.max(c.hi, next.hi)), acc)
-          case c => loop(ni, nj, next, acc :+ c)
-    loop(0, 0, null, Vector.empty)
+    val builder = ArraySeq.newBuilder[Range]
+    builder.sizeHint(ranges.length + other.ranges.length)
+    var i = 0
+    var j = 0
+    var cur: Range | Null = null
+    while i < ranges.length || j < other.ranges.length do
+      val takeFromA = j >= other.ranges.length || (i < ranges.length && ranges(i).lo <= other.ranges(j).lo)
+      val next = if takeFromA then ranges(i) else other.ranges(j)
+      if takeFromA then i += 1 else j += 1
+      cur match
+        case null => cur = next
+        case c if next.lo <= c.hi + 1 => cur = Range(c.lo, math.max(c.hi, next.hi))
+        case c =>
+          builder += c
+          cur = next
+    cur match
+      case null => ()
+      case c => builder += c
+    CharSet(builder.result())
   def |(other: CharSet): CharSet = union(other)
 
   infix def intersect(other: CharSet): CharSet =

--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -283,7 +283,30 @@ final class CharSet @publicInBinary private[CharSet] (private val ranges: ArrayS
 
   def isEmpty: Boolean = ranges.isEmpty
 
-  infix def union(other: CharSet): CharSet = CharSet.normalize(ranges ++ other.ranges)
+  /**
+   * Two-pointer merge of the two already-sorted, already-coalesced range sequences, O(n+m) -
+   * as opposed to flattening both into one list and re-sorting from scratch (what
+   * `CharSet.normalize(ranges ++ other.ranges)` used to do here, at O((n+m) log(n+m))), which
+   * throws away the fact that both inputs are already ordered. Mirrors `intersect`'s existing
+   * two-pointer walk, just coalescing overlapping/adjacent ranges (`normalize`'s rule) instead
+   * of intersecting them.
+   */
+  infix def union(other: CharSet): CharSet =
+    @tailrec
+    def loop(i: Int, j: Int, cur: Range | Null, acc: Vector[Range]): CharSet =
+      if i >= ranges.length && j >= other.ranges.length then
+        CharSet(ArraySeq.from(cur match
+          case null => acc
+          case c => acc :+ c))
+      else
+        val takeFromA = j >= other.ranges.length || (i < ranges.length && ranges(i).lo <= other.ranges(j).lo)
+        val next = if takeFromA then ranges(i) else other.ranges(j)
+        val (ni, nj) = if takeFromA then (i + 1, j) else (i, j + 1)
+        cur match
+          case null => loop(ni, nj, next, acc)
+          case c if next.lo <= c.hi + 1 => loop(ni, nj, Range(c.lo, math.max(c.hi, next.hi)), acc)
+          case c => loop(ni, nj, next, acc :+ c)
+    loop(0, 0, null, Vector.empty)
   def |(other: CharSet): CharSet = union(other)
 
   infix def intersect(other: CharSet): CharSet =

--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -291,12 +291,9 @@ final class CharSet @publicInBinary private[CharSet] (private val ranges: ArrayS
    * two-pointer walk, just coalescing overlapping/adjacent ranges (`normalize`'s rule) instead
    * of intersecting them.
    *
-   * Written as a `while` loop writing straight into an `ArraySeq.newBuilder` (sized up front
-   * via `sizeHint`) rather than an immutable `Vector` accumulator converted to `ArraySeq` at
-   * the end (`intersect`/`complement`/`normalize`'s style, and this method's own first cut):
-   * benchmarked ~2.3-2.8x faster across `rangeCount` 50-5000, since it skips both the `Vector`
-   * node allocations and the full extra copy `ArraySeq.from` needs to flatten them into an
-   * array.
+   * Writes straight into an `ArraySeq.newBuilder`, unlike `intersect`/`complement`/`normalize`
+   * which accumulate into a `Vector` and convert via `ArraySeq.from` at the end - skips both
+   * the `Vector` node allocations and that final copy.
    */
   infix def union(other: CharSet): CharSet =
     val builder = ArraySeq.newBuilder[Range]

--- a/test/CharSetTest.scala
+++ b/test/CharSetTest.scala
@@ -106,6 +106,39 @@ class CharSetTest extends munit.FunSuite:
     assertEquals(CharSet.empty.union(a), a)
   }
 
+  test("union interleaves multi-range operands without merging when disjoint") {
+    val a = CharSet.normalize(Range(0, 2), Range(10, 12), Range(20, 22))
+    val b = CharSet.normalize(Range(5, 7), Range(15, 17), Range(25, 27))
+    val expected = Vector(Range(0, 2), Range(5, 7), Range(10, 12), Range(15, 17), Range(20, 22), Range(25, 27))
+    assertEquals(a.union(b).iterator.toVector, expected)
+    assertEquals(b.union(a).iterator.toVector, expected)
+  }
+
+  test("union merges a bridging range from the other operand across a gap") {
+    // b's single range overlaps both of a's ranges and the gap between them, so all three
+    // must coalesce into one - a two-pointer merge that only ever compares current heads
+    // (rather than re-sorting the flattened input) has to keep extending the same run.
+    val a = CharSet.normalize(Range(0, 2), Range(10, 12))
+    val b = CharSet.normalize(Range(1, 11))
+    assertEquals(a.union(b).iterator.toVector, Vector(Range(0, 12)))
+    assertEquals(b.union(a).iterator.toVector, Vector(Range(0, 12)))
+  }
+
+  test("union merges a range from the other operand that exactly fills the gap") {
+    val a = CharSet.normalize(Range(0, 2), Range(10, 12))
+    val b = CharSet.normalize(Range(3, 9))
+    assertEquals(a.union(b).iterator.toVector, Vector(Range(0, 12)))
+    assertEquals(b.union(a).iterator.toVector, Vector(Range(0, 12)))
+  }
+
+  test("union of multi-range operands with a mix of merges and gaps") {
+    val a = CharSet.normalize(Range(0, 2), Range(10, 12), Range(30, 32))
+    val b = CharSet.normalize(Range(1, 11), Range(20, 22))
+    val expected = Vector(Range(0, 12), Range(20, 22), Range(30, 32))
+    assertEquals(a.union(b).iterator.toVector, expected)
+    assertEquals(b.union(a).iterator.toVector, expected)
+  }
+
   test("intersect is commutative") {
     val a = CharSet.range('a', 'm')
     val b = CharSet.range('h', 'z')


### PR DESCRIPTION
## Summary
Closes #44.

`ranges` and `other.ranges` are each already sorted and coalesced (`CharSet`'s own invariant, maintained by every smart constructor), but `union` threw that away:

```scala
infix def union(other: CharSet): CharSet = CharSet.normalize(ranges ++ other.ranges)
```

`normalize` does a full `.sortBy(_.lo)` on the concatenation - O((n+m) log(n+m)) when a linear two-pointer merge suffices, mirroring `intersect`'s existing structure right next to it in the same file. Replaced with a two-pointer merge-with-coalescing: walk both sequences comparing current heads, coalescing overlapping/adjacent ranges per `normalize`'s own rule (`next.lo <= cur.hi + 1`) instead of intersecting them.

This compounds through `Regex.alt`'s character-class merge path (`chars.iterator.map(_.set).foldLeft(CharSet.empty)(_ union _)` - a chain of `union` calls for an n-way alternation) and `RegexParser.parseClassUnion` (character classes mixing shorthand escapes/nested subclasses with plain ranges).

## Test plan
- [x] Added `CharSetTest` cases for multi-range interleaved operands (no merge needed, one operand's range bridging a gap in the other, exactly filling a gap, a mix) - written and verified passing against the *old* implementation first, then confirmed still passing against the new one. The existing tests all used single-range operands per side, which a buggy two-pointer merge could pass trivially.
- [x] `scala-cli test . --exclude "bench/**"` - full suite green (CharSetTest 29/29)
- [x] `scala-cli --power fmt --check .`
- [x] `scala-cli --power compile . --exclude "bench/**" --platform scala-js --js-version 1.22.0`
- [x] `bench/CharSetBenchmark.union` before/after (JMH, `-f 1 -wi 2 -i 3 -w 300ms -r 300ms`, noisy at this iteration count but the magnitude is clear):
  - `rangeCount=500`: ~160,574 ns/op → ~8,159 ns/op (~20x)
  - `rangeCount=5000`: ~552,390 ns/op → ~86,057 ns/op (~6x)