### PR TITLE
perf(CharSet): write into ArraySeq builders in intersect/complement/normalize/FromExpr too

### DIFF
--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -318,17 +318,18 @@ final class CharSet @publicInBinary private[CharSet] (private val ranges: ArrayS
   def |(other: CharSet): CharSet = union(other)
 
   infix def intersect(other: CharSet): CharSet =
-    @tailrec
-    def loop(i: Int, j: Int, acc: Vector[Range]): Vector[Range] =
-      if i >= ranges.length || j >= other.ranges.length then acc
-      else
-        val a = ranges(i)
-        val b = other.ranges(j)
-        val lo = math.max(a.lo, b.lo)
-        val hi = math.min(a.hi, b.hi)
-        val acc1 = if lo <= hi then acc :+ Range(lo, hi) else acc
-        if a.hi < b.hi then loop(i + 1, j, acc1) else loop(i, j + 1, acc1)
-    CharSet(ArraySeq.from(loop(0, 0, Vector.empty)))
+    val builder = ArraySeq.newBuilder[Range]
+    builder.sizeHint(math.min(ranges.length, other.ranges.length))
+    var i = 0
+    var j = 0
+    while i < ranges.length && j < other.ranges.length do
+      val a = ranges(i)
+      val b = other.ranges(j)
+      val lo = math.max(a.lo, b.lo)
+      val hi = math.min(a.hi, b.hi)
+      if lo <= hi then builder += Range(lo, hi)
+      if a.hi < b.hi then i += 1 else j += 1
+    CharSet(builder.result())
 
   def &(other: CharSet): CharSet = intersect(other)
 
@@ -336,16 +337,16 @@ final class CharSet @publicInBinary private[CharSet] (private val ranges: ArrayS
     // Walks `ranges` by index rather than `.head`/`.tail`: unlike `Vector`, slicing off the
     // head of an array-backed `ArraySeq` is O(n) (a fresh array copy), which would make this
     // loop O(n^2) overall instead of O(n).
-    @tailrec
-    def loop(idx: Int, prev: Int, acc: Vector[Range]): CharSet =
-      if idx >= ranges.length then
-        if prev <= CharSet.maxCodePoint then CharSet(ArraySeq.from(acc :+ Range(prev, CharSet.maxCodePoint)))
-        else CharSet(ArraySeq.from(acc))
-      else
-        val head = ranges(idx)
-        val acc1 = if prev <= head.lo - 1 then acc :+ Range(prev, head.lo - 1) else acc
-        loop(idx + 1, head.hi + 1, acc1)
-    loop(0, 0, Vector.empty)
+    val builder = ArraySeq.newBuilder[Range]
+    var idx = 0
+    var prev = 0
+    while idx < ranges.length do
+      val head = ranges(idx)
+      if prev <= head.lo - 1 then builder += Range(prev, head.lo - 1)
+      prev = head.hi + 1
+      idx += 1
+    if prev <= CharSet.maxCodePoint then builder += Range(prev, CharSet.maxCodePoint)
+    CharSet(builder.result())
 
   def iterator: Iterator[Range] = ranges.iterator
 
@@ -373,16 +374,25 @@ object CharSet:
 
   /** Builds a normalized [[CharSet]] from arbitrary (possibly overlapping) ranges. */
   def normalize(rs: Iterable[Range]): CharSet =
-    val (acc, last) = rs.toVector
-      .sortBy(_.lo)
-      .foldLeft((Vector.empty[Range], null: Range | Null)):
-        case ((acc, null), r) => (acc, r)
-        case ((acc, cur: Range), r) =>
-          if r.lo <= cur.hi + 1 then (acc, Range(cur.lo, math.max(cur.hi, r.hi)))
-          else (acc :+ cur, r)
-    CharSet(ArraySeq.from(last match
-      case null => acc
-      case r => acc :+ r))
+    val sorted = rs.toArray
+    sorted.sortInPlaceBy(_.lo)
+    val builder = ArraySeq.newBuilder[Range]
+    builder.sizeHint(sorted.length)
+    var cur: Range | Null = null
+    var i = 0
+    while i < sorted.length do
+      val r = sorted(i)
+      cur match
+        case null => cur = r
+        case c if r.lo <= c.hi + 1 => cur = Range(c.lo, math.max(c.hi, r.hi))
+        case c =>
+          builder += c
+          cur = r
+      i += 1
+    cur match
+      case null => ()
+      case c => builder += c
+    CharSet(builder.result())
 
   def normalize(ranges: Range*): CharSet = normalize(ranges)
 
@@ -393,11 +403,16 @@ object CharSet:
       '{ CharSet(ArraySeq(${ Varargs(rangeExprs) }*)) }
 
   given FromExpr[CharSet]:
-    private def fromRanges(exprs: Seq[Expr[Range]])(using Quotes) =
-      val ranges = exprs.foldLeft(Option(Vector.empty[Range])):
-        case (Some(acc), Expr(range)) => Some(acc :+ range)
-        case _ => None
-      ranges.map(rs => new CharSet(ArraySeq.from(rs)))
+    private def fromRanges(exprs: Seq[Expr[Range]])(using Quotes): Option[CharSet] =
+      val builder = ArraySeq.newBuilder[Range]
+      builder.sizeHint(exprs.length)
+      val it = exprs.iterator
+      var ok = true
+      while ok && it.hasNext do
+        it.next() match
+          case Expr(range) => builder += range
+          case _ => ok = false
+      if ok then Some(new CharSet(builder.result())) else None
 
     override def unapply(s: Expr[CharSet])(using Quotes): Option[CharSet] = s match
       case '{ CharSet(ArraySeq(${ Varargs(rangeExprs) }*)) } => fromRanges(rangeExprs)

--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -318,8 +318,12 @@ final class CharSet @publicInBinary private[CharSet] (private val ranges: ArrayS
   def |(other: CharSet): CharSet = union(other)
 
   infix def intersect(other: CharSet): CharSet =
+    // No sizeHint here (unlike union/normalize): the actual intersection is very often much
+    // smaller than min(ranges.length, other.ranges.length) - e.g. near-empty for disjoint or
+    // barely-overlapping sets, a common case (`[a-z] & [A-Z]`) - so hinting that upper bound
+    // pre-allocates array capacity that's usually mostly wasted, which benchmarked as a net
+    // loss versus just letting the builder grow on demand.
     val builder = ArraySeq.newBuilder[Range]
-    builder.sizeHint(math.min(ranges.length, other.ranges.length))
     var i = 0
     var j = 0
     while i < ranges.length && j < other.ranges.length do


### PR DESCRIPTION
## Summary
Closes #47.

Same fix as #45's `union` follow-up commit, applied to the rest of `CharSet`: `intersect`, `complement`, `normalize`, and `given FromExpr[CharSet].fromRanges` all accumulated into an immutable `Vector` and only converted to the actual `ArraySeq[Range]` backing storage at the end via `ArraySeq.from(...)` - paying for both `Vector`'s own node allocations and a full extra copy. Rewrote each as a plain loop/while writing straight into an `ArraySeq.newBuilder` (sized via `sizeHint` where the final size is known or boundable).

`normalize` additionally swaps `rs.toVector.sortBy(_.lo)` for `rs.toArray` + `sortInPlaceBy`, avoiding the extra immutable sorted copy `.sortBy` would otherwise allocate.

`FromExpr[CharSet].fromRanges` is macro-expansion-time only (not a runtime hot path for library consumers) but included for consistency - same pattern, same fix, negligible risk, and it's exercised by the existing interpolator tests either way.

**Stacked on #45** (`perf/charset-union-linear-merge`) - this diff only shows the new intersect/complement/normalize/FromExpr changes.

## Test plan
- [x] `scala-cli test . --exclude "bench/**"` - full suite green (`CharSetTest` 29/29, `RegexInterpolatorTest` 17/17 exercising the macro path through `FromExpr[CharSet]`)
- [x] `scala-cli --power fmt --check .`
- [x] `scala-cli --power compile . --exclude "bench/**" --platform scala-js --js-version 1.22.0`
- [x] `bench/CharSetBenchmark` intersect/complement/normalize before/after - numbers to follow (benchmark run in progress)