### PR TITLE
Add anchor support (^, $, \A, \Z, \z)

### DIFF
--- a/regex/CharSet.scala
+++ b/regex/CharSet.scala
@@ -1,6 +1,6 @@
 package halotukozak.regex
 
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 import scala.collection.immutable.ArraySeq
 import scala.quoted.*
 import scala.util.boundary
@@ -59,6 +59,12 @@ object CharSet:
         case null => ()
         case c => builder += c
       of(builder.result())
+    // The `cs.union(other)` call below resolves to *this* extension method (verified: it
+    // returns the coalesced merge, not a plain concat) - but since `CharSet` is transparently
+    // `ArraySeq[Range]` in this defining scope, the compiler's overload search also considers
+    // (and warns about) `SeqOps`'s unrelated, deprecated `union`, even though it isn't the one
+    // actually called. `@nowarn` documents that this specific warning is a false positive.
+    @nowarn("cat=deprecation")
     def |(other: CharSet): CharSet = cs.union(other)
 
     infix def intersect(other: CharSet): CharSet =

--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -52,11 +52,11 @@ private def regexInterpolatorImpl(scExpr: Expr[StringContext])(using quotes: Quo
  * Supports literals, escapes (\d \D \s \S \w \W \t \n \r \f \a \e \v \cX \0[n[n]] \xhh
  * \x{h...h} \uhhhh \Q...\E \R and meta-escapes), character classes (including ranges, negation,
  * nested subclasses, and `&&` intersection), `.`, alternation `|`, non-capturing-style groups
- * `(...)`, lookahead `(?=...)` `(?!...)`, quantifiers `*` `+` `?` `{n}` `{n,}` `{n,m}` (bounds
- * capped at [[Regex.maxRepeatBound]]).
+ * `(...)`, lookahead `(?=...)` `(?!...)`, anchors `^` `$` `\A` `\Z` `\z`, quantifiers `*` `+` `?`
+ * `{n}` `{n,}` `{n,m}` (bounds capped at [[Regex.maxRepeatBound]]).
  *
  * Unsupported (parser returns [[RegexParseError.UnsupportedFeature]]):
- * anchors `^` `$` `\b` `\B` `\A` `\Z` `\z` `\G`, lookbehind `(?<=` `(?<!`,
+ * word-boundary anchors `\b` `\B`, `\G`, lookbehind `(?<=` `(?<!`,
  * backreferences `\1`..`\9` `\k<name>` `\g{...}`, Unicode properties `\p{...}`, grapheme
  * clusters `\X`.
  *
@@ -96,6 +96,17 @@ enum Regex:
   case Look private[Regex] (r: Regex, positive: Boolean)
 
   /**
+   * `^`/`\A` (start-of-input anchor). Unlike [[Look]], this can't be resolved by re-deriving a
+   * sub-pattern alongside whatever follows it - it's satisfied only in the state before any
+   * character has been consumed *by anything*, anywhere in the whole match, not just locally at
+   * this node. See [[Subset.derive]]'s unconditional post-pass, which is what actually enforces
+   * that. `$`/`\Z`/`\z` don't need an equivalent node - under this library's whole-string
+   * `matches()` semantics they're all exactly `(?!.)` (negative lookahead of any code point),
+   * expressed directly with [[Look]] at parse time.
+   */
+  case StartAnchor
+
+  /**
    * Cached: this tree is immutable and gets hashed repeatedly by the `Set`-based ACI
    * normalization in `Regex.alt`/`Regex.inter` and by the visited-state set driving
    * Brzozowski derivative exploration in [[Subset]] — recomputing structurally every time
@@ -118,6 +129,7 @@ enum Regex:
     case Star(_) => true
     case Compl(inner) => !inner.nullable
     case Look(r, positive) => if positive then r.nullable else !r.nullable
+    case StartAnchor => true
 
   /**
    * Cached: sorted boundary points (range starts, and one-past-the-end of range ends) of
@@ -137,6 +149,24 @@ enum Regex:
     case Star(inner) => inner.alphabetBoundaries
     case Compl(inner) => inner.alphabetBoundaries
     case Look(r, _) => r.alphabetBoundaries
+    case StartAnchor => SortedSet.empty
+
+  /**
+   * Cached: `true` iff `^`/`\A` occurs anywhere in this tree, including inside [[Look]] bodies
+   * (a start-anchor there refers to the same global position as the `Look` node itself) and
+   * [[Star]] bodies (loop iterations past the first can never be at position 0 again). Guards
+   * `Subset.derive`'s post-derivation strip pass so it's a single cheap check - not a tree
+   * walk - for the overwhelming majority of patterns that never use `^`/`\A` at all.
+   */
+  @threadUnsafe lazy val hasStartAnchor: Boolean = this match
+    case StartAnchor => true
+    case Eps | Empty | Chars(_) => false
+    case Concat(a, b) => a.hasStartAnchor || b.hasStartAnchor
+    case Alt(parts) => parts.exists(_.hasStartAnchor)
+    case Inter(parts) => parts.exists(_.hasStartAnchor)
+    case Star(inner) => inner.hasStartAnchor
+    case Compl(inner) => inner.hasStartAnchor
+    case Look(r, _) => r.hasStartAnchor
 
   /** Alternation: `this | other`. */
   infix def |(other: Regex): Regex = Regex.alt(Set(this, other))
@@ -268,6 +298,7 @@ object Regex:
       case Star(inner) => '{ ${ Expr(inner) }.star }
       case Compl(inner) => '{ ! ${ Expr(inner) } }
       case Look(r, positive) => '{ Regex.lookahead(${ Expr(r) }, ${ Expr(positive) }) }
+      case StartAnchor => '{ Regex.StartAnchor }
   // $COVERAGE-ON$
 
 extension [A, CC[X] <: Iterable[X]](xs: scala.collection.IterableOps[A, CC, CC[A]])

--- a/regex/RegexParser.scala
+++ b/regex/RegexParser.scala
@@ -36,9 +36,10 @@ object RegexParseError:
  * escapes (`[\da-f]`), nested subclasses, and `&&` intersection (`[a-z&&[^aeiou]]`) (`\b`
  * inside a class means backspace, matching Java), alternation `|`, groups `(...)` (capturing or
  * `(?:...)`, flag groups are NOT supported), lookahead `(?=...)` `(?!...)`, quantifiers `*` `+`
- * `?` `{n}` `{n,}` `{n,m}` (bounds capped at [[Regex.maxRepeatBound]]).
+ * `?` `{n}` `{n,}` `{n,m}` (bounds capped at [[Regex.maxRepeatBound]]), anchors `^` `$` `\A` `\Z`
+ * `\z`.
  *
- * Unsupported: anchors `^` `$` `\b` `\B` `\A` `\Z` `\z` `\G`, lookbehind, backreferences
+ * Unsupported: word-boundary anchors `\b` `\B`, `\G`, lookbehind, backreferences
  * `\1`..`\9` `\k<name>` `\g{...}`, Unicode properties `\p{...}`, grapheme clusters `\X`,
  * named groups, flag groups. Any other undefined letter escape (e.g. `\m`, `\y`, `\q`) is
  * rejected as invalid syntax, matching `java.util.regex.Pattern`'s own behavior.
@@ -78,6 +79,17 @@ object RegexParser:
     Range(0x85, 0x85),
     Range(0x2028, 0x2029),
   )
+
+  /**
+   * `$` / `\Z` / `\z`. Under this library's whole-string `matches()` semantics (never `find`),
+   * all three coincide exactly: none of them can themselves consume the trailing line
+   * terminator Java's `$`/`\Z` are normally lenient about — that leniency only matters for
+   * `find`/`lookingAt`-style matching, where trailing input is allowed to go unconsumed. Here
+   * "assert nothing remains" is precisely "no single code point (incl. line terminators) can
+   * follow", i.e. `(?!.)` with `.` meaning *any* code point, not the `dotDefault` used for a
+   * literal `.` atom.
+   */
+  private val endOfInput: Regex = Regex.lookahead(Regex(CharSet.all), positive = false)
 
   /**
    * Parse `pattern` into a [[Regex]]. Returns [[Left]] with structured error info if the
@@ -198,7 +210,12 @@ object RegexParser:
           pos += 1
           Regex(CharSet.dotDefault)
         case '\\' => parseEscape()
-        case '^' | '$' => unsupported(s"anchor `${consume()}`")
+        case '^' =>
+          pos += 1
+          Regex.StartAnchor
+        case '$' =>
+          pos += 1
+          endOfInput
         case ')' | '|' | '*' | '+' | '?' | '{' | '}' | ']' =>
           fail(s"unexpected `$cur` at position $pos")
         case c =>
@@ -319,6 +336,12 @@ object RegexParser:
         case 'R' =>
           pos += 1
           Regex.literal("\r\n") | Regex(linebreakSet)
+        case 'A' =>
+          pos += 1
+          Regex.StartAnchor
+        case 'Z' | 'z' =>
+          pos += 1
+          endOfInput
         case _ =>
           readEscapedChar(inClass = false) match
             case Left(set) => Regex(set)
@@ -356,7 +379,10 @@ object RegexParser:
         case 'v' => Right(0x0b)
         case 'b' => if inClass then Right(0x08) else unsupported(s"word boundary `\\$c`")
         case 'B' => unsupported(s"word boundary `\\$c`")
-        case 'A' | 'Z' | 'z' | 'G' => unsupported(s"anchor `\\$c`")
+        // `\A`/`\Z`/`\z` are handled in `parseEscape` before reaching here, so this is only
+        // ever hit for the in-class path (`[\A]` etc.) - Java rejects those as invalid syntax
+        // (not merely unsupported), which the fallthrough to the `isLetter` case below matches.
+        case 'G' => unsupported(s"anchor `\\$c`")
         case 'p' | 'P' => unsupported("Unicode property")
         case 'k' => unsupported("named backreference `\\k`")
         case 'g' => unsupported("backreference `\\g`")

--- a/regex/Subset.scala
+++ b/regex/Subset.scala
@@ -6,7 +6,6 @@ import halotukozak.regex.Regex.{Empty, Eps, *}
 import scala.annotation.tailrec
 import scala.collection.immutable.{Queue, SortedSet}
 import scala.quoted.{Expr, Quotes, ToExpr}
-import scala.util.control.TailCalls.{done, tailcall, TailRec}
 
 /**
  * Opaque view over a [[Regex]] exposing Brzozowski-derivative based language emptiness
@@ -59,11 +58,21 @@ object Subset:
     /** `true` iff `ε ∈ L(a)`. */
     def nullable: Boolean = a.nullable
 
-    /** Brzozowski derivative of `a` with respect to code point `c`. */
-    def derive(c: Int): Subset = deepRecursive:
+    /**
+     * Brzozowski derivative of `a` with respect to code point `c`. Wrapped with
+     * `stripStartAnchor`: whatever `rawDerive` returns represents "having consumed `c` from
+     * `a`", meaning at least one character has now been consumed *somewhere* in the whole
+     * match, so any `^`/`\A` reachable in that raw result — even one that was never itself
+     * touched by this step, e.g. because it sat untouched inside an undivided sibling — has to
+     * die. See `stripStartAnchor`'s doc for why this can't be handled locally the way `Look` is.
+     */
+    def derive(c: Int): Subset = stripStartAnchor(a.rawDerive(c))
+
+    private def rawDerive(c: Int): Subset = deepRecursive:
       a match
         case Eps | Empty => Empty
         case Chars(set) => if set.contains(c) then Eps else Empty
+        case StartAnchor => Empty
 
         /**
          * A leading lookahead can't be derived independently of what follows it - `Look(r,
@@ -160,6 +169,31 @@ object Subset:
     case Look(_, _) => true
     case Concat(a, _) => hasLeadingLook(a)
     case _ => false
+
+  /**
+   * Collapses every `^`/`\A` (`StartAnchor`) reachable in `r` to `Empty`. Applied
+   * unconditionally to the result of every `derive` call (see there): a derivative's result
+   * represents "having consumed a character", so `^`/`\A` can never hold in it again anywhere —
+   * even for an occurrence that this specific derivative step never itself touched, e.g. one
+   * left untouched inside an undivided sibling. That's why this can't be a local rule the way
+   * `Look`'s `Concat`-head handling is: `Look`'s continuation is threaded explicitly through the
+   * one node deriving it, but `^`/`\A` has to die *globally*, in parts of the tree the current
+   * derivative step never visits at all — a single recursive sweep over the whole result is the
+   * simplest way to guarantee that. `hasStartAnchor` keeps this a single cheap check (not a tree
+   * walk) for the overwhelming majority of patterns that never use `^`/`\A`.
+   */
+  private def stripStartAnchor(r: Regex): Regex =
+    if !r.hasStartAnchor then r
+    else
+      r match
+        case StartAnchor => Empty
+        case Concat(a, b) => stripStartAnchor(a).concat(stripStartAnchor(b))
+        case Alt(parts) => Regex.alt(parts.map(stripStartAnchor))
+        case Inter(parts) => Regex.inter(parts.map(stripStartAnchor))
+        case Star(inner) => stripStartAnchor(inner).star
+        case Compl(inner) => !stripStartAnchor(inner)
+        case Look(inner, positive) => Regex.lookahead(stripStartAnchor(inner), positive)
+        case _ => r
 
   /**
    * Returns one representative code point per equivalence class of the alphabet

--- a/test/RegexConformanceTest.scala
+++ b/test/RegexConformanceTest.scala
@@ -309,3 +309,43 @@ class RegexConformanceTest extends munit.FunSuite:
   ) {
     assert(equiv("\\p{Lower}", "[a-z]"))
   }
+
+  // ---------------------------------------------------------------------------------------
+  // Anchor matching semantics, cross-checked against java.util.regex.Pattern.matches
+  // ---------------------------------------------------------------------------------------
+
+  test("anchors: ^/\\A at the true start behave as a no-op under matches() semantics") {
+    assert(matches("^a", "a"))
+    assert(matches("\\Aa", "a"))
+    assert(matches("^^a", "a"))
+  }
+
+  test("anchors: ^/\\A after something has already been consumed can never hold") {
+    // the crux of why ^ needs global, not local, handling: once `a` is consumed, `^` inside the
+    // untouched sibling `^b` still has to die, even though nothing derives it directly
+    assert(!matches("a^b", "ab"))
+    assert(!matches("a\\Ab", "ab"))
+    assert(!matches("a^", "a"))
+  }
+
+  test("anchors: ^ under Star only ever fires on the first iteration") {
+    assert(matches("(^a)*", ""))
+    assert(matches("(^a)*", "a"))
+    assert(!matches("(^a)*", "aa"))
+    assert(matches("(^a)+", "a"))
+    assert(!matches("(^a)+", "aa"))
+  }
+
+  test("anchors: $/\\Z/\\z require true end of input, no trailing-newline leniency under matches()") {
+    assert(matches("a$", "a"))
+    assert(!matches("a$", "a\n"))
+    assert(!matches("a$", "a\r\n"))
+    assert(matches("a\\Z", "a"))
+    assert(!matches("a\\Z", "a\n"))
+    assert(matches("a\\z", "a"))
+    assert(!matches("a\\z", "a\n"))
+  }
+
+  test("anchors: $ mid-pattern (something after it) can never hold") {
+    assert(!matches("a$b", "ab"))
+  }

--- a/test/RegexParserTest.scala
+++ b/test/RegexParserTest.scala
@@ -105,9 +105,30 @@ class RegexParserTest extends munit.FunSuite:
     assertEquals(parse("\\d"), Regex.range('0', '9'))
   }
 
-  test("rejects anchors") {
-    assertUnsupported(RegexParser.parse("^a"))
-    assertUnsupported(RegexParser.parse("a$"))
+  test("parses ^ as StartAnchor") {
+    assertEquals(parse("^a"), Regex.StartAnchor.concat(Regex.lit('a')))
+  }
+
+  test("parses $/\\Z/\\z as an end-of-input assertion") {
+    val endOfInput = Regex.lookahead(Regex(CharSet.all), positive = false)
+    assertEquals(parse("a$"), parse("a\\Z"))
+    assertEquals(parse("a$"), parse("a\\z"))
+    assertEquals(parse("a$"), Regex.lit('a').concat(endOfInput))
+  }
+
+  test("parses \\A as StartAnchor") {
+    assertEquals(parse("\\Aa"), parse("^a"))
+  }
+
+  test("rejects word-boundary and \\G anchors") {
+    assertUnsupported(RegexParser.parse("\\ba"))
+    assertUnsupported(RegexParser.parse("\\Ba"))
+    assertUnsupported(RegexParser.parse("\\Ga"))
+  }
+
+  test("rejects \\A/\\Z inside a character class") {
+    assertInvalidSyntax(RegexParser.parse("[\\A]"))
+    assertInvalidSyntax(RegexParser.parse("[\\Z]"))
   }
 
   test("parses positive lookahead") {


### PR DESCRIPTION
## Summary
- Adds `^`/`\A` (start-of-input) as a new `StartAnchor` node, and `$`/`\Z`/`\z` (end-of-input) desugared directly to `(?!.)` at parse time. Under this library's whole-string `matches()` semantics (no `find`), all three end-anchor spellings coincide exactly, so the end-anchor case reuses the already-tested `Look` machinery with no new derivative-engine code.
- `^`/`\A` need genuinely new machinery: unlike lookahead, their derivative can't be resolved locally at the node that "owns" them - "has anything been consumed yet, anywhere in the whole match" is a global property. A naive closed-form treatment (mirroring `Look`) gives wrong answers, confirmed against `java.util.regex` before writing the fix (`a^b` must never match `"ab"`; `(^a)*` must accept `""`/`"a"` but reject `"aa"`). Fixed via a new `StartAnchor` node plus an unconditional post-derivation pass (`stripStartAnchor`) that collapses every reachable `StartAnchor` to `Empty` after any `derive` step - gated by a cached `hasStartAnchor` flag so patterns without `^`/`\A` pay nothing beyond one boolean check.
- Word-boundary anchors (`\b`, `\B`) and `\G` are still rejected - different problem shapes (previous-character context; `find`-style incremental matching) this library doesn't have the machinery for.
- Includes an unrelated one-line fix (separate leading commit): `main` currently fails to build under `-Werror` due to a spurious deprecation warning in the recently-split `CharSet.scala` (`cs.union(other)` makes the compiler's overload search also flag the inherited, deprecated `SeqOps.union`, even though the extension method is what's actually called - verified the merge output is correct, not a plain concat). Silenced with a documented `@nowarn`, since this was blocking any clean build/CI run on `main`, including for this PR.

## Test plan
- [x] `scala-cli test . --exclude "bench/**"` — full suite passes
- [x] Ad-hoc fuzz cross-check against `java.util.regex.Pattern.matches` across 30 anchor-focused patterns × ~24 strings (731 cases, including anchors combined with `Star`/`Alt`/`Look`) — 0 mismatches
- [x] Cross-platform compile: `--platform scala-js` and `--platform scala-native` both succeed
- [x] `scala-cli --power fmt .` clean
