### PR TITLE
Add JMH benchmark coverage for lookahead, anchors, and (?i)

### DIFF
--- a/bench/RegexBenchmark.scala
+++ b/bench/RegexBenchmark.scala
@@ -40,3 +40,11 @@ class RegexBenchmark:
 
   @Benchmark
   def parse(): Regex = RegexParser.parse(pattern).toOption.get
+
+  // Same shape as `pattern` above, wrapped in `(?i)` - the only one of lookahead/anchors/(?i)
+  // with real parse-time cost, since case folding expands every literal/range CharSet as it's
+  // built (see RegexParser.foldRange/foldCharSet). Directly comparable to `parse` above.
+  private val caseInsensitivePattern = s"(?i)$pattern"
+
+  @Benchmark
+  def parseCaseInsensitive(): Regex = RegexParser.parse(caseInsensitivePattern).toOption.get

--- a/bench/SubsetBenchmark.scala
+++ b/bench/SubsetBenchmark.scala
@@ -61,3 +61,44 @@ class SubsetBenchmark:
   @Benchmark
   def deriveChain(): Boolean =
     "user@example.com".foldLeft(narrow)((s, c) => s.derive(c.toInt)).nullable
+
+  // A leading lookahead re-derives its own body alongside the continuation at every step
+  // (Concat(Look(...), b)'s special case) - directly comparable to deriveChain above (same
+  // 17-char input), showing the delta that extra derivation costs.
+  private val lookaheadGuarded =
+    Subset.parse("""(?=[a-zA-Z0-9._%+-]+@)[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.(com|org|net|io)""").toOption.get
+
+  @Benchmark
+  def deriveChainWithLookahead(): Boolean =
+    "user@example.com".foldLeft(lookaheadGuarded)((s, c) => s.derive(c.toInt)).nullable
+
+  // Exercises the pricier Concat(Alt(parts), b) redistribution path, only taken when an Alt
+  // branch is itself a leading lookahead (see Subset.derive's doc) - the first character has
+  // to derive every branch concatenated with the continuation separately, instead of sharing
+  // it the way an ordinary alternation does.
+  private val lookaheadInAlternation = Subset.parse("""((?=a)|[b-z])[a-z]{0,20}""").toOption.get
+
+  @Benchmark
+  def deriveChainWithLookaheadInAlt(): Boolean =
+    "bxxxxxxxxxxxxxxxxxxxx".foldLeft(lookaheadInAlternation)((s, c) => s.derive(c.toInt)).nullable
+
+  // ^/\A cost an unconditional hasStartAnchor check on every derive() result (see
+  // stripStartAnchor's doc); guarded so it's a single boolean read once the anchor is gone
+  // from the residual (after the first character) rather than a tree walk. Comparable to
+  // deriveChain above.
+  private val anchored =
+    Subset.parse("""^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.(com|org|net|io)$""").toOption.get
+
+  @Benchmark
+  def deriveChainWithAnchors(): Boolean =
+    "user@example.com".foldLeft(anchored)((s, c) => s.derive(c.toInt)).nullable
+
+  // (?i) folding happens entirely at parse time (see RegexBenchmark.parseCaseInsensitive for
+  // that cost) - derive-time cost here is only whatever a handful of extra CharSet ranges adds
+  // to contains's binary search, so this should land close to deriveChain above.
+  private val caseInsensitive =
+    Subset.parse("""(?i)[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.(COM|ORG|NET|IO)""").toOption.get
+
+  @Benchmark
+  def deriveChainCaseInsensitive(): Boolean =
+    "USER@EXAMPLE.COM".foldLeft(caseInsensitive)((s, c) => s.derive(c.toInt)).nullable

--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -4,7 +4,7 @@ import halotukozak.commons.deepRecursive
 
 import scala.annotation.{threadUnsafe, unused}
 import scala.collection.immutable.SortedSet
-import scala.quoted.{Expr, Quotes, ToExpr}
+import scala.quoted.{Expr, Quotes, ToExpr, Varargs}
 import scala.util.hashing.MurmurHash3
 
 /**
@@ -284,22 +284,32 @@ object Regex:
     else s.foldRight(Eps: Regex)((c, acc) => lit(c).concat(acc))
 
   // $COVERAGE-OFF$
+  /**
+   * Embeds the value via the raw case constructors directly, instead of regenerating it through
+   * the public smart constructors (`concat`, `alt`, `inter`, `star`, `unary_!`, `lookahead`) at
+   * every call site. The smart constructors exist to (re-)establish ACI normalization and merge
+   * `Chars` sets when building a tree from scratch; a `Regex` value reaching this `given` is
+   * already normalized, so re-running them at every macro call site - and again at every class
+   * load, since the generated code re-executes them - would just redo that work for a result
+   * that's already known. The raw constructors are accessible here because this `given` lives
+   * inside `object Regex`, in the same scope as the `private[Regex]` cases themselves.
+   */
   given ToExpr[Regex]:
     def apply(r: Regex)(using Quotes): Expr[Regex] = r match
       case Eps => '{ Regex.Eps }
       case Empty => '{ Regex.Empty }
-      case Chars(set) => '{ Regex(${ Expr(set) }) }
-      case Concat(a, b) => '{ ${ Expr(a) }.concat(${ Expr(b) }) }
-      case Alt(parts) =>
-        val partsExpr = Expr.ofSeq(parts.toSeq.map(Expr(_)))
-        '{ Regex.alt($partsExpr) }
-      case Inter(parts) =>
-        val partsExpr = Expr.ofSeq(parts.toSeq.map(Expr(_)))
-        '{ Regex.inter($partsExpr) }
-      case Star(inner) => '{ ${ Expr(inner) }.star }
-      case Compl(inner) => '{ ! ${ Expr(inner) } }
-      case Look(r, positive) => '{ Regex.lookahead(${ Expr(r) }, ${ Expr(positive) }) }
       case StartAnchor => '{ Regex.StartAnchor }
+      case Chars(set) => '{ Regex.Chars(${ Expr(set) }) }
+      case Concat(a, b) => '{ Regex.Concat(${ Expr(a) }, ${ Expr(b) }) }
+      case Star(inner) => '{ Regex.Star(${ Expr(inner) }) }
+      case Compl(inner) => '{ Regex.Compl(${ Expr(inner) }) }
+      case Look(inner, positive) => '{ Regex.Look(${ Expr(inner) }, ${ Expr(positive) }) }
+      case Alt(parts) =>
+        val partsExpr = Varargs(parts.toSeq.map(Expr(_)))
+        '{ Regex.Alt(Set($partsExpr*)) }
+      case Inter(parts) =>
+        val partsExpr = Varargs(parts.toSeq.map(Expr(_)))
+        '{ Regex.Inter(Set($partsExpr*)) }
   // $COVERAGE-ON$
 
 extension [A, CC[X] <: Iterable[X]](xs: scala.collection.IterableOps[A, CC, CC[A]])


### PR DESCRIPTION
## Summary
- Adds `SubsetBenchmark` cases for `deriveChainWithLookahead`, `deriveChainWithLookaheadInAlt` (the pricier `Concat(Alt(parts), b)` redistribution path), `deriveChainWithAnchors`, and `deriveChainCaseInsensitive` - all directly comparable to the existing `deriveChain` baseline (same 17-char input).
- Adds a `RegexBenchmark.parseCaseInsensitive` case comparable to the existing `parse` baseline (same pattern, wrapped in `(?i)`), isolating case-folding's parse-time cost specifically - the only one of the three features with real parse-time overhead (lookahead/anchors just build ordinary AST nodes).

Targets `feat/case-insensitive` (#57) rather than `main` since the `(?i)` benchmark needs that PR's parser support - rebase target once #57 merges.

## Local numbers (informational, single-fork/short-iteration smoke run - not representative of CI's numbers)
```
SubsetBenchmark.deriveChain                     6.4 us/op
SubsetBenchmark.deriveChainCaseInsensitive      5.8 us/op
SubsetBenchmark.deriveChainWithAnchors          2.6 us/op
SubsetBenchmark.deriveChainWithLookahead       15.7 us/op
SubsetBenchmark.deriveChainWithLookaheadInAlt   3.9 us/op

RegexBenchmark.parse                    (branches=10)   17.3 us/op
RegexBenchmark.parseCaseInsensitive     (branches=10)   15.7 us/op
RegexBenchmark.parse                    (branches=200)  17.3 us/op
RegexBenchmark.parseCaseInsensitive     (branches=200)  23.4 us/op
```

## Test plan
- [x] `scala-cli run --jmh . --exclude "test/**" -- SubsetBenchmark` and `-- RegexBenchmark.parse` both run cleanly
- [x] `scala-cli test . --exclude "bench/**"` — full suite still passes (bench-only change)
- [x] `scala-cli --power fmt .` clean
