### PR TITLE
fix(Regex): make regex"..." macro expansion stack-safe on deep patterns

### DIFF
--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -311,113 +311,80 @@ object Regex:
 
   // $COVERAGE-OFF$
   /**
-   * A pending step in [[ToExpr]]'s iterative post-order walk: index `node`'s children first
-   * (`Enter`), then, once they're all indexed, `node` itself (`Exit`).
-   */
-  private enum ExprBuildStep:
-    case Enter(node: Regex)
-    case Exit(node: Regex)
-
-  /**
-   * Per-node tag in the compact string [[ToExpr]] produces - plain (no `extends java.lang.Enum`)
-   * so it stays pure Scala, matching this file's own cross-platform (JVM/Scala.js/Scala Native)
-   * goal; `.ordinal`/`fromOrdinal` are all the round-trip needs, and nothing outside this file
-   * ever sees a `RegexTag` value, so there's no reason to take on a JVM-only Java-interop type.
+   * Per-node tag in the compact encoding [[RegexEncoder]]/[[RegexDecoder]] round-trip through -
+   * plain (no `extends java.lang.Enum`) so it stays pure Scala, matching this file's own
+   * cross-platform (JVM/Scala.js/Scala Native) goal; `.ordinal`/`fromOrdinal` are all the round
+   * trip needs, and nothing outside this file ever sees a `RegexTag` value, so there's no reason
+   * to take on a JVM-only Java-interop type.
    */
   private enum RegexTag:
     case Eps, Empty, Chars, Concat, Alt, Inter, Star, Compl, Look, StartAnchor, Repeat
 
   /**
-   * Reconstructs a `Regex` from the two compact strings [[ToExpr]] produces: `nodesPart` is a
-   * `,`-joined `tag,arg1,arg2,arg3` quadruple per node (nodes laid out so every child index is
-   * smaller than its parent's), and `partsFlatPart` is a `,`-joined flat list of [[Alt]]/[[Inter]]
-   * children indices. A single forward pass then builds each node from its already-built
-   * children, with no recursion at all on either side of this round trip.
+   * Encodes a `Regex` into the flat, compact form [[RegexDecoder]] reconstructs from - a pure
+   * function with no `Quotes`/macro dependency at all, unlike [[ToExpr]] below, which only needs
+   * one to splice the already-computed [[Encoded]] fields as literals. Keeping the traversal pure
+   * means it's exercisable (and unit-testable) exactly like any other function, with no
+   * `regex"..."` call or macro-expansion context required.
    *
-   * `arg1`/`arg2`/`arg3` are reused across tags rather than given one array per case, since at
-   * most three ints are ever needed per node:
-   *  - [[Concat]]: `arg1`/`arg2` = index of `a`/`b`.
-   *  - [[Star]]/[[Compl]]: `arg1` = index of the inner `r`.
-   *  - [[Look]]: `arg1` = index of `r`; `arg2` = `positive` as `0`/`1`.
-   *  - [[Repeat]]: `arg1` = index of `r`; `arg2`/`arg3` = `lo`/`hi`.
-   *  - [[Chars]]: `arg1` = index into `charSets`.
-   *  - [[Alt]]/[[Inter]]: `arg1`/`arg2` = offset/count of this node's children within `partsFlat`.
-   *
-   * Strings, not the five parallel `Array[Int]` literals an earlier version of this used, because
-   * each element of an embedded array literal costs its own `dup`/`ldc`/`iastore` bytecode
-   * instructions - enough of them (e.g. from a long literal string; see [[ToExpr]]) hits the
-   * JVM's 64KB-per-method bytecode ceiling. A string constant is one `ldc` regardless of length,
-   * so the call site's bytecode size no longer scales with the source pattern's size at all; the
-   * only remaining limit is the classfile format's 65535-byte cap on a single constant. Two
-   * strings rather than one joined by a delimiter, since there's already an unambiguous split
-   * between them (a fixed parameter each) - no delimiter to pick or reparse.
+   * Splicing raw constructor calls one-per-node instead (an earlier version of this did) isn't
+   * enough on its own: `regex"..."` on a pattern producing a sufficiently deep tree - not just
+   * from a `{lo,hi}` quantifier (see [[Repeat]], which now keeps those O(1)), but e.g. from a
+   * long literal string, since [[literal]] still builds one [[Concat]] node per character - can
+   * `StackOverflowError` the *compiler itself* while it walks that many levels of nested calls in
+   * a later phase (macro splicing, inlining), regardless of how carefully the splicing macro
+   * itself was written. [[Encoded]] is flat data, embedded as a single call with no nesting, so
+   * no compiler pass has a deep tree to walk no matter how deep the source `Regex` is.
    */
-  private[regex] def fromEncoded(nodesPart: String, partsFlatPart: String, charSets: IndexedSeq[CharSet]): Regex =
-    val nodeInts = nodesPart.split(',').map(_.toInt)
-    val partsFlat = if partsFlatPart.isEmpty then Array.empty[Int] else partsFlatPart.split(',').map(_.toInt)
+  private[regex] object RegexEncoder:
 
-    val n = nodeInts.length / 4
-    val nodes = new Array[Regex](n)
-    var i = 0
-    while i < n do
-      val arg1 = nodeInts(i * 4 + 1)
-      val arg2 = nodeInts(i * 4 + 2)
-      val arg3 = nodeInts(i * 4 + 3)
-      nodes(i) = RegexTag.fromOrdinal(nodeInts(i * 4)) match
-        case RegexTag.Eps => Eps
-        case RegexTag.Empty => Empty
-        case RegexTag.StartAnchor => StartAnchor
-        case RegexTag.Chars => Chars(charSets(arg1))
-        case RegexTag.Concat => Concat(nodes(arg1), nodes(arg2))
-        case RegexTag.Star => Star(nodes(arg1))
-        case RegexTag.Compl => Compl(nodes(arg1))
-        case RegexTag.Look => Look(nodes(arg1), arg2 != 0)
-        case RegexTag.Repeat => Repeat(nodes(arg1), arg2, arg3)
-        case tag @ (RegexTag.Alt | RegexTag.Inter) =>
-          var parts = Set.empty[Regex]
-          var k = 0
-          while k < arg2 do
-            parts += nodes(partsFlat(arg1 + k))
-            k += 1
-          if tag == RegexTag.Alt then Alt(parts) else Inter(parts)
-      i += 1
-    nodes(n - 1)
+    /**
+     * `nodesPart`: `,`-joined `tag,arg1,arg2,arg3` quadruple per node (nodes laid out so every
+     * child index is smaller than its parent's). `partsFlatPart`: `,`-joined flat list of
+     * [[Alt]]/[[Inter]] children indices. `charSets`: one entry per distinct [[Chars]] leaf, in
+     * encounter order.
+     *
+     * `arg1`/`arg2`/`arg3` are reused across tags rather than given one field per case, since at
+     * most three ints are ever needed per node:
+     *  - [[Concat]]: `arg1`/`arg2` = index of `a`/`b`.
+     *  - [[Star]]/[[Compl]]: `arg1` = index of the inner `r`.
+     *  - [[Look]]: `arg1` = index of `r`; `arg2` = `positive` as `0`/`1`.
+     *  - [[Repeat]]: `arg1` = index of `r`; `arg2`/`arg3` = `lo`/`hi`.
+     *  - [[Chars]]: `arg1` = index into `charSets`.
+     *  - [[Alt]]/[[Inter]]: `arg1`/`arg2` = offset/count of this node's children within `partsFlat`.
+     *
+     * Two strings, not one joined by a delimiter: there's already an unambiguous split between
+     * them (a field each), so there's no delimiter to pick or reparse. And strings at all, not
+     * the five parallel `Array[Int]` literals an earlier version of this used, because each
+     * element of an embedded array literal costs its own `dup`/`ldc`/`iastore` bytecode
+     * instructions - enough of them (e.g. from a long literal string) hits the JVM's
+     * 64KB-per-method bytecode ceiling at the `regex"..."` call site. A string constant is one
+     * `ldc` regardless of length, so that call site's bytecode size no longer scales with the
+     * source pattern's size at all; the only remaining limit is the classfile format's
+     * 65535-byte cap on a single constant.
+     */
+    final case class Encoded(nodesPart: String, partsFlatPart: String, charSets: IndexedSeq[CharSet])
 
-  /**
-   * Embeds the value's already-computed shape as a compact string reconstructed by
-   * [[fromEncoded]], instead of regenerating it through the public smart constructors (`concat`,
-   * `alt`, `inter`, `star`, `unary_!`, `lookahead`) at every call site - the same spirit as
-   * [[TokenMatcher]]'s `ToExpr` embedding its DFA tables as plain data. The smart constructors
-   * exist to (re-)establish ACI normalization and merge `Chars` sets when building a tree from
-   * scratch; a `Regex` value reaching this `given` is already normalized, so re-running them at
-   * every macro call site - and again at every class load, since the generated code re-executes
-   * them - would just redo that work for a result that's already known.
-   *
-   * Splicing raw constructor calls one-per-node instead (as an earlier version of this `given`
-   * did) still isn't enough on its own: `regex"..."` on a pattern producing a sufficiently deep
-   * tree - not just from a `{lo,hi}` quantifier (see [[Repeat]], which now keeps those O(1)), but
-   * e.g. from a long literal string, since [[literal]] still builds one [[Concat]] node per
-   * character - can `StackOverflowError` the *compiler itself* while it walks that many levels
-   * of nested calls in a later phase (macro splicing, inlining), regardless of how carefully
-   * *this* macro was written. Embedding as a single string is a single call with no nesting, so
-   * no compiler pass has a deep tree to walk no matter how deep the source `Regex` is - see
-   * [[fromEncoded]] for why a string beats parallel `Array[Int]` literals for that same call
-   * site's own bytecode size, which was still an (orthogonal, JVM-classfile-level) limit on a
-   * long enough pattern even after this fix's first version closed the stack-overflow.
-   *
-   * Both directions avoid recursion entirely: encoding below walks the tree with an explicit
-   * `steps` stack (needed because, unlike [[halotukozak.commons.deepRecursive]]-trampolined
-   * `concat`/`derive`, [[Alt]]/[[Inter]] recurse into a `Set` of unbounded size, which that
-   * machinery can't unroll), and [[fromEncoded]]'s reconstruction is a single forward loop.
-   *
-   * `index` doubles as a dedup cache: a subtree reachable from multiple places in the tree (e.g.
-   * a repeated alternative) is encoded, and later reconstructed, only once.
-   */
-  given ToExpr[Regex]:
-    def apply(r: Regex)(using Quotes): Expr[Regex] =
-      import ExprBuildStep.*
+    /**
+     * A pending step in the iterative post-order walk: index `node`'s children first (`Enter`),
+     * then, once they're all indexed, `node` itself (`Exit`). Explicit, rather than plain
+     * recursion or [[halotukozak.commons.deepRecursive]] (which trampolines `concat`/`derive`),
+     * because [[Alt]]/[[Inter]] recurse into a `Set` of unbounded size, which that machinery
+     * can't unroll - and ordinary recursion here would risk overflowing the *compiler's* stack
+     * while expanding `regex"..."` on a deep pattern.
+     */
+    private enum Step:
+      case Enter(node: Regex)
+      case Exit(node: Regex)
+
+    /**
+     * `index` doubles as a dedup cache: a subtree reachable from multiple places in the tree
+     * (e.g. a repeated alternative) is encoded only once.
+     */
+    def encode(r: Regex): Encoded =
+      import Step.*
       val index = mutable.Map.empty[Regex, Int]
-      val tags = mutable.ArrayBuffer.empty[Int]
+      val tags = mutable.ArrayBuffer.empty[RegexTag]
       val arg1 = mutable.ArrayBuffer.empty[Int]
       val arg2 = mutable.ArrayBuffer.empty[Int]
       val arg3 = mutable.ArrayBuffer.empty[Int]
@@ -427,7 +394,7 @@ object Regex:
 
       def push(tag: RegexTag, a: Int, b: Int, c: Int): Int =
         val idx = tags.length
-        tags += tag.ordinal
+        tags += tag
         arg1 += a
         arg2 += b
         arg3 += c
@@ -488,11 +455,69 @@ object Regex:
 
       val nodesPart = Iterator
         .range(0, tags.length)
-        .flatMap(i => Iterator(tags(i), arg1(i), arg2(i), arg3(i)))
+        .flatMap(i => Iterator(tags(i).ordinal, arg1(i), arg2(i), arg3(i)))
         .mkString(",")
-      val partsFlatPart = partsFlat.mkString(",")
-      val charSetsExpr = Varargs(charSets.toSeq.map(Expr(_)))
-      '{ Regex.fromEncoded(${ Expr(nodesPart) }, ${ Expr(partsFlatPart) }, IndexedSeq($charSetsExpr*)) }
+      Encoded(nodesPart, partsFlat.mkString(","), charSets.toIndexedSeq)
+
+  /**
+   * Reconstructs a `Regex` from an [[RegexEncoder.Encoded]] value: a single forward pass builds
+   * each node from its already-built children, with no recursion at all - the counterpart to
+   * [[RegexEncoder]]'s iterative encode, and, like it, a pure function with no macro dependency.
+   */
+  private[regex] object RegexDecoder:
+    def decode(nodesPart: String, partsFlatPart: String, charSets: IndexedSeq[CharSet]): Regex =
+      val nodeInts = nodesPart.split(',').map(_.toInt)
+      val partsFlat = if partsFlatPart.isEmpty then Array.empty[Int] else partsFlatPart.split(',').map(_.toInt)
+
+      val n = nodeInts.length / 4
+      val nodes = new Array[Regex](n)
+      var i = 0
+      while i < n do
+        val arg1 = nodeInts(i * 4 + 1)
+        val arg2 = nodeInts(i * 4 + 2)
+        val arg3 = nodeInts(i * 4 + 3)
+        nodes(i) = RegexTag.fromOrdinal(nodeInts(i * 4)) match
+          case RegexTag.Eps => Eps
+          case RegexTag.Empty => Empty
+          case RegexTag.StartAnchor => StartAnchor
+          case RegexTag.Chars => Chars(charSets(arg1))
+          case RegexTag.Concat => Concat(nodes(arg1), nodes(arg2))
+          case RegexTag.Star => Star(nodes(arg1))
+          case RegexTag.Compl => Compl(nodes(arg1))
+          case RegexTag.Look => Look(nodes(arg1), arg2 != 0)
+          case RegexTag.Repeat => Repeat(nodes(arg1), arg2, arg3)
+          case tag @ (RegexTag.Alt | RegexTag.Inter) =>
+            var parts = Set.empty[Regex]
+            var k = 0
+            while k < arg2 do
+              parts += nodes(partsFlat(arg1 + k))
+              k += 1
+            if tag == RegexTag.Alt then Alt(parts) else Inter(parts)
+        i += 1
+      nodes(n - 1)
+
+  /**
+   * Embeds the value's already-computed [[RegexEncoder.Encoded]] shape, reconstructed by
+   * [[RegexDecoder]], instead of regenerating it through the public smart constructors (`concat`,
+   * `alt`, `inter`, `star`, `unary_!`, `lookahead`) at every call site - the same spirit as
+   * [[TokenMatcher]]'s `ToExpr` embedding its DFA tables as plain data. The smart constructors
+   * exist to (re-)establish ACI normalization and merge `Chars` sets when building a tree from
+   * scratch; a `Regex` value reaching this `given` is already normalized, so re-running them at
+   * every macro call site - and again at every class load, since the generated code re-executes
+   * them - would just redo that work for a result that's already known. See [[RegexEncoder]] for
+   * why the encoding is flat data rather than nested constructor calls.
+   */
+  given ToExpr[Regex]:
+    def apply(r: Regex)(using Quotes): Expr[Regex] =
+      val encoded = RegexEncoder.encode(r)
+      val charSetsExpr = Varargs(encoded.charSets.toSeq.map(Expr(_)))
+      '{
+        Regex.RegexDecoder.decode(
+          ${ Expr(encoded.nodesPart) },
+          ${ Expr(encoded.partsFlatPart) },
+          IndexedSeq($charSetsExpr*),
+        )
+      }
   // $COVERAGE-ON$
 
 extension [A, CC[X] <: Iterable[X]](xs: scala.collection.IterableOps[A, CC, CC[A]])

--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -4,6 +4,7 @@ import halotukozak.commons.deepRecursive
 
 import scala.annotation.{threadUnsafe, unused}
 import scala.collection.immutable.SortedSet
+import scala.collection.mutable
 import scala.quoted.{Expr, Quotes, ToExpr, Varargs}
 import scala.util.hashing.MurmurHash3
 
@@ -86,6 +87,14 @@ enum Regex:
   /** Kleene star `r*`. */
   case Star private[Regex] (r: Regex)
 
+  /**
+   * Bounded repetition `r{lo,hi}` (`hi` may be `Int.MaxValue` for the unbounded `{lo,}` form).
+   * Kept as a single node carrying `lo`/`hi` symbolically, instead of unfolding into that many
+   * copies of `r` - see [[Regex.repeat]] for why, and [[Subset.rawDerive]] for how a Brzozowski
+   * derivative is taken through it without ever materializing the unfolded form.
+   */
+  case Repeat private[Regex] (r: Regex, lo: Int, hi: Int)
+
   /** Complement `¬r`. */
   case Compl private[Regex] (r: Regex)
 
@@ -128,6 +137,7 @@ enum Regex:
     case Alt(parts) => parts.exists(_.nullable)
     case Inter(parts) => parts.forall(_.nullable)
     case Star(_) => true
+    case Repeat(r, lo, _) => lo == 0 || r.nullable
     case Compl(inner) => !inner.nullable
     case Look(r, positive) => if positive then r.nullable else !r.nullable
     case StartAnchor => true
@@ -148,6 +158,7 @@ enum Regex:
     case Alt(parts) => parts.iterator.map(_.alphabetBoundaries).reduce(_ ++ _)
     case Inter(parts) => parts.iterator.map(_.alphabetBoundaries).reduce(_ ++ _)
     case Star(inner) => inner.alphabetBoundaries
+    case Repeat(inner, _, _) => inner.alphabetBoundaries
     case Compl(inner) => inner.alphabetBoundaries
     case Look(r, _) => r.alphabetBoundaries
     case StartAnchor => SortedSet.empty
@@ -166,6 +177,7 @@ enum Regex:
     case Alt(parts) => parts.exists(_.hasStartAnchor)
     case Inter(parts) => parts.exists(_.hasStartAnchor)
     case Star(inner) => inner.hasStartAnchor
+    case Repeat(inner, _, _) => inner.hasStartAnchor
     case Compl(inner) => inner.hasStartAnchor
     case Look(r, _) => r.hasStartAnchor
 
@@ -188,16 +200,28 @@ enum Regex:
 
   def * : Regex = star
 
-  /** Quantifier `this{n,m}` where m can be `Int.MaxValue` for unbounded. */
+  /**
+   * Quantifier `this{lo,hi}` where `hi` can be `Int.MaxValue` for unbounded. Produces a single
+   * [[Repeat]] node carrying `lo`/`hi` symbolically - not `lo`/`hi` copies of `this` - the way
+   * `regex-syntax` (Rust's regex crate) keeps counted repetitions unexpanded in its `Hir` so AST
+   * size stays proportional to the pattern's *text*, not the language it denotes; a `{1,1000}`
+   * quantifier used to mean ~1000 [[Concat]]/[[Alt]] nodes here too, which was both wasted
+   * allocation on every call and, when spliced by `regex"..."`'s `ToExpr[Regex]`, deep enough to
+   * overflow the compiler's own stack expanding the macro.
+   */
   def repeat(lo: Int, hi: Int): Regex =
     require(lo >= 0 && hi >= lo, s"invalid bounds {$lo,$hi}")
     require(
       lo <= Regex.maxRepeatBound && (hi == Int.MaxValue || hi <= Regex.maxRepeatBound),
       s"quantifier bound exceeds maximum supported value of ${Regex.maxRepeatBound} (got {$lo,$hi})",
     )
-    val mandatory = (1 to lo).foldLeft[Regex](Regex.Eps)((acc, _) => this.concat(acc))
-    if hi == Int.MaxValue then mandatory.concat(star)
-    else mandatory.concat((1 to (hi - lo)).foldLeft[Regex](Regex.Eps)((acc, _) => Regex.Eps | this.concat(acc)))
+    this match
+      case _ if hi == 0 => Regex.Eps
+      case Regex.Eps => Regex.Eps
+      case Regex.Empty => if lo == 0 then Regex.Eps else Regex.Empty
+      case _ if lo == 0 && hi == Int.MaxValue => star
+      case _ if lo == 1 && hi == 1 => this
+      case _ => Regex.Repeat(this, lo, hi)
 
 object Regex:
 
@@ -211,10 +235,12 @@ object Regex:
         case _ => Concat(a, b)
 
   /**
-   * Upper bound on quantifier bounds accepted by [[repeat]]. `{n,m}` is unfolded into an
-   * `n`- (or `m`-) sized chain of [[Concat]] nodes, so unbounded values would let a single
-   * malformed pattern build an unbounded/exponential AST. Real-world token patterns never
-   * need bounds anywhere near this size.
+   * Upper bound on quantifier bounds accepted by [[repeat]]. `Repeat` itself stays O(1)
+   * regardless of `lo`/`hi` (see [[repeat]]), but each Brzozowski derivative step through it
+   * (`Subset.rawDerive`) peels one repetition off, so exploring `L(r{0,hi})` up to a fixed point
+   * (`Subset.isEmpty`/`subset`) still visits on the order of `hi` distinct states - an unbounded
+   * value would let a single malformed pattern blow up that exploration. Real-world token
+   * patterns never need bounds anywhere near this size.
    */
   val maxRepeatBound: Int = 1000
 
@@ -285,31 +311,183 @@ object Regex:
 
   // $COVERAGE-OFF$
   /**
-   * Embeds the value via the raw case constructors directly, instead of regenerating it through
-   * the public smart constructors (`concat`, `alt`, `inter`, `star`, `unary_!`, `lookahead`) at
-   * every call site. The smart constructors exist to (re-)establish ACI normalization and merge
-   * `Chars` sets when building a tree from scratch; a `Regex` value reaching this `given` is
-   * already normalized, so re-running them at every macro call site - and again at every class
-   * load, since the generated code re-executes them - would just redo that work for a result
-   * that's already known. The raw constructors are accessible here because this `given` lives
-   * inside `object Regex`, in the same scope as the `private[Regex]` cases themselves.
+   * A pending step in [[ToExpr]]'s iterative post-order walk: index `node`'s children first
+   * (`Enter`), then, once they're all indexed, `node` itself (`Exit`).
+   */
+  private enum ExprBuildStep:
+    case Enter(node: Regex)
+    case Exit(node: Regex)
+
+  inline private val EpsTag = 0
+  inline private val EmptyTag = 1
+  inline private val CharsTag = 2
+  inline private val ConcatTag = 3
+  inline private val AltTag = 4
+  inline private val InterTag = 5
+  inline private val StarTag = 6
+  inline private val ComplTag = 7
+  inline private val LookTag = 8
+  inline private val StartAnchorTag = 9
+  inline private val RepeatTag = 10
+
+  /**
+   * Reconstructs a `Regex` from the flat encoding [[ToExpr]] produces: nodes laid out so every
+   * child index is smaller than its parent's, letting a single forward pass build each node from
+   * its already-built children with no recursion at all, on either side of this round trip.
+   *
+   * `arg1`/`arg2`/`arg3` are reused across tags rather than given one array per case, since at
+   * most three ints are ever needed per node:
+   *  - [[Concat]]: `arg1`/`arg2` = index of `a`/`b`.
+   *  - [[Star]]/[[Compl]]: `arg1` = index of the inner `r`.
+   *  - [[Look]]: `arg1` = index of `r`; `arg2` = `positive` as `0`/`1`.
+   *  - [[Repeat]]: `arg1` = index of `r`; `arg2`/`arg3` = `lo`/`hi`.
+   *  - [[Chars]]: `arg1` = index into `charSets`.
+   *  - [[Alt]]/[[Inter]]: `arg1`/`arg2` = offset/count of this node's children within `partsFlat`.
+   */
+  private[regex] def fromEncoded(
+    tags: Array[Int],
+    arg1: Array[Int],
+    arg2: Array[Int],
+    arg3: Array[Int],
+    partsFlat: Array[Int],
+    charSets: IndexedSeq[CharSet],
+  ): Regex =
+    val nodes = new Array[Regex](tags.length)
+    var i = 0
+    while i < tags.length do
+      nodes(i) = tags(i) match
+        case EpsTag => Eps
+        case EmptyTag => Empty
+        case StartAnchorTag => StartAnchor
+        case CharsTag => Chars(charSets(arg1(i)))
+        case ConcatTag => Concat(nodes(arg1(i)), nodes(arg2(i)))
+        case StarTag => Star(nodes(arg1(i)))
+        case ComplTag => Compl(nodes(arg1(i)))
+        case LookTag => Look(nodes(arg1(i)), arg2(i) != 0)
+        case RepeatTag => Repeat(nodes(arg1(i)), arg2(i), arg3(i))
+        case AltTag | InterTag =>
+          val off = arg1(i)
+          val cnt = arg2(i)
+          var parts = Set.empty[Regex]
+          var k = 0
+          while k < cnt do
+            parts += nodes(partsFlat(off + k))
+            k += 1
+          if tags(i) == AltTag then Alt(parts) else Inter(parts)
+      i += 1
+    nodes(tags.length - 1)
+
+  /**
+   * Embeds the value's already-computed shape as flat `Array[Int]` tables reconstructed by
+   * [[fromEncoded]], instead of regenerating it through the public smart constructors (`concat`,
+   * `alt`, `inter`, `star`, `unary_!`, `lookahead`) at every call site - the same approach
+   * [[TokenMatcher]]'s `ToExpr` uses to embed its DFA tables. The smart constructors exist to
+   * (re-)establish ACI normalization and merge `Chars` sets when building a tree from scratch; a
+   * `Regex` value reaching this `given` is already normalized, so re-running them at every macro
+   * call site - and again at every class load, since the generated code re-executes them - would
+   * just redo that work for a result that's already known.
+   *
+   * Splicing raw constructor calls one-per-node instead (as an earlier version of this `given`
+   * did) still isn't enough on its own: `regex"..."` on a pattern producing a sufficiently deep
+   * tree - not just from a `{lo,hi}` quantifier (see [[Repeat]], which now keeps those O(1)), but
+   * e.g. from a long literal string, since [[literal]] still builds one [[Concat]] node per
+   * character - can `StackOverflowError` the *compiler itself* while it walks that many levels
+   * of nested calls in a later phase (macro splicing, inlining), regardless of how carefully
+   * *this* macro was written. A flat array is embedded as a single call with no nesting, so no
+   * compiler pass has a deep tree to walk no matter how deep the source `Regex` is.
+   *
+   * Both directions avoid recursion entirely: encoding below walks the tree with an explicit
+   * `steps` stack (needed because, unlike [[halotukozak.commons.deepRecursive]]-trampolined
+   * `concat`/`derive`, [[Alt]]/[[Inter]] recurse into a `Set` of unbounded size, which that
+   * machinery can't unroll), and [[fromEncoded]]'s reconstruction is a single forward loop.
+   *
+   * `index` doubles as a dedup cache: a subtree reachable from multiple places in the tree (e.g.
+   * a repeated alternative) is encoded, and later reconstructed, only once.
    */
   given ToExpr[Regex]:
-    def apply(r: Regex)(using Quotes): Expr[Regex] = r match
-      case Eps => '{ Regex.Eps }
-      case Empty => '{ Regex.Empty }
-      case StartAnchor => '{ Regex.StartAnchor }
-      case Chars(set) => '{ Regex.Chars(${ Expr(set) }) }
-      case Concat(a, b) => '{ Regex.Concat(${ Expr(a) }, ${ Expr(b) }) }
-      case Star(inner) => '{ Regex.Star(${ Expr(inner) }) }
-      case Compl(inner) => '{ Regex.Compl(${ Expr(inner) }) }
-      case Look(inner, positive) => '{ Regex.Look(${ Expr(inner) }, ${ Expr(positive) }) }
-      case Alt(parts) =>
-        val partsExpr = Varargs(parts.toSeq.map(Expr(_)))
-        '{ Regex.Alt(Set($partsExpr*)) }
-      case Inter(parts) =>
-        val partsExpr = Varargs(parts.toSeq.map(Expr(_)))
-        '{ Regex.Inter(Set($partsExpr*)) }
+    def apply(r: Regex)(using Quotes): Expr[Regex] =
+      import ExprBuildStep.*
+      val index = mutable.Map.empty[Regex, Int]
+      val tags = mutable.ArrayBuffer.empty[Int]
+      val arg1 = mutable.ArrayBuffer.empty[Int]
+      val arg2 = mutable.ArrayBuffer.empty[Int]
+      val arg3 = mutable.ArrayBuffer.empty[Int]
+      val partsFlat = mutable.ArrayBuffer.empty[Int]
+      val charSets = mutable.ArrayBuffer.empty[CharSet]
+      val steps = mutable.ArrayDeque(Enter(r))
+
+      def push(tag: Int, a: Int, b: Int, c: Int): Int =
+        val idx = tags.length
+        tags += tag
+        arg1 += a
+        arg2 += b
+        arg3 += c
+        idx
+
+      def enter(node: Regex): Unit = if !index.contains(node) then steps += Enter(node)
+
+      while steps.nonEmpty do
+        steps.removeLast() match
+          case Enter(node) if index.contains(node) => ()
+          case Enter(node) =>
+            node match
+              case Eps => index(node) = push(EpsTag, 0, 0, 0)
+              case Empty => index(node) = push(EmptyTag, 0, 0, 0)
+              case StartAnchor => index(node) = push(StartAnchorTag, 0, 0, 0)
+              case Chars(set) =>
+                val csIdx = charSets.length
+                charSets += set
+                index(node) = push(CharsTag, csIdx, 0, 0)
+              case Concat(a, b) =>
+                steps += Exit(node)
+                enter(b)
+                enter(a)
+              case Star(inner) =>
+                steps += Exit(node)
+                enter(inner)
+              case Repeat(inner, _, _) =>
+                steps += Exit(node)
+                enter(inner)
+              case Compl(inner) =>
+                steps += Exit(node)
+                enter(inner)
+              case Look(inner, _) =>
+                steps += Exit(node)
+                enter(inner)
+              case Alt(parts) =>
+                steps += Exit(node)
+                parts.foreach(enter)
+              case Inter(parts) =>
+                steps += Exit(node)
+                parts.foreach(enter)
+          case Exit(node) =>
+            index(node) = node match
+              case Concat(a, b) => push(ConcatTag, index(a), index(b), 0)
+              case Star(inner) => push(StarTag, index(inner), 0, 0)
+              case Repeat(inner, lo, hi) => push(RepeatTag, index(inner), lo, hi)
+              case Compl(inner) => push(ComplTag, index(inner), 0, 0)
+              case Look(inner, positive) => push(LookTag, index(inner), if positive then 1 else 0, 0)
+              case Alt(parts) =>
+                val off = partsFlat.length
+                parts.foreach(p => partsFlat += index(p))
+                push(AltTag, off, parts.size, 0)
+              case Inter(parts) =>
+                val off = partsFlat.length
+                parts.foreach(p => partsFlat += index(p))
+                push(InterTag, off, parts.size, 0)
+              case leaf => throw MatchError(s"unreachable: leaf node $leaf pushed as Exit")
+
+      val charSetsExpr = Varargs(charSets.toSeq.map(Expr(_)))
+      '{
+        Regex.fromEncoded(
+          ${ Expr(tags.toArray) },
+          ${ Expr(arg1.toArray) },
+          ${ Expr(arg2.toArray) },
+          ${ Expr(arg3.toArray) },
+          ${ Expr(partsFlat.toArray) },
+          IndexedSeq($charSetsExpr*),
+        )
+      }
   // $COVERAGE-ON$
 
 extension [A, CC[X] <: Iterable[X]](xs: scala.collection.IterableOps[A, CC, CC[A]])

--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -318,24 +318,21 @@ object Regex:
     case Enter(node: Regex)
     case Exit(node: Regex)
 
-  inline private val EpsTag = 0
-  inline private val EmptyTag = 1
-  inline private val CharsTag = 2
-  inline private val ConcatTag = 3
-  inline private val AltTag = 4
-  inline private val InterTag = 5
-  inline private val StarTag = 6
-  inline private val ComplTag = 7
-  inline private val LookTag = 8
-  inline private val StartAnchorTag = 9
-  inline private val RepeatTag = 10
+  /**
+   * Per-node tag in the compact string [[ToExpr]] produces - plain (no `extends java.lang.Enum`)
+   * so it stays pure Scala, matching this file's own cross-platform (JVM/Scala.js/Scala Native)
+   * goal; `.ordinal`/`fromOrdinal` are all the round-trip needs, and nothing outside this file
+   * ever sees a `RegexTag` value, so there's no reason to take on a JVM-only Java-interop type.
+   */
+  private enum RegexTag:
+    case Eps, Empty, Chars, Concat, Alt, Inter, Star, Compl, Look, StartAnchor, Repeat
 
   /**
-   * Reconstructs a `Regex` from the compact string [[ToExpr]] produces: `nodes|partsFlat`, where
-   * `nodes` is a `,`-joined `tag,arg1,arg2,arg3` quadruple per node (nodes laid out so every
-   * child index is smaller than its parent's) and `partsFlat` is a `,`-joined flat list of
-   * [[Alt]]/[[Inter]] children indices. A single forward pass then builds each node from its
-   * already-built children, with no recursion at all on either side of this round trip.
+   * Reconstructs a `Regex` from the two compact strings [[ToExpr]] produces: `nodesPart` is a
+   * `,`-joined `tag,arg1,arg2,arg3` quadruple per node (nodes laid out so every child index is
+   * smaller than its parent's), and `partsFlatPart` is a `,`-joined flat list of [[Alt]]/[[Inter]]
+   * children indices. A single forward pass then builds each node from its already-built
+   * children, with no recursion at all on either side of this round trip.
    *
    * `arg1`/`arg2`/`arg3` are reused across tags rather than given one array per case, since at
    * most three ints are ever needed per node:
@@ -346,44 +343,43 @@ object Regex:
    *  - [[Chars]]: `arg1` = index into `charSets`.
    *  - [[Alt]]/[[Inter]]: `arg1`/`arg2` = offset/count of this node's children within `partsFlat`.
    *
-   * A single string, not the five parallel `Array[Int]` literals an earlier version of this used,
-   * because each element of an embedded array literal costs its own `dup`/`ldc`/`iastore`
-   * bytecode instructions - enough of them (e.g. from a long literal string; see [[ToExpr]]) hits
-   * the JVM's 64KB-per-method bytecode ceiling. A string constant is one `ldc` regardless of
-   * length, so the call site's bytecode size no longer scales with the source pattern's size at
-   * all; the only remaining limit is the classfile format's 65535-byte cap on a single constant.
+   * Strings, not the five parallel `Array[Int]` literals an earlier version of this used, because
+   * each element of an embedded array literal costs its own `dup`/`ldc`/`iastore` bytecode
+   * instructions - enough of them (e.g. from a long literal string; see [[ToExpr]]) hits the
+   * JVM's 64KB-per-method bytecode ceiling. A string constant is one `ldc` regardless of length,
+   * so the call site's bytecode size no longer scales with the source pattern's size at all; the
+   * only remaining limit is the classfile format's 65535-byte cap on a single constant. Two
+   * strings rather than one joined by a delimiter, since there's already an unambiguous split
+   * between them (a fixed parameter each) - no delimiter to pick or reparse.
    */
-  private[regex] def fromEncoded(encoded: String, charSets: IndexedSeq[CharSet]): Regex =
-    val bar = encoded.indexOf('|')
-    val nodeInts = encoded.substring(0, bar).split(',').map(_.toInt)
-    val partsFlatStr = encoded.substring(bar + 1)
-    val partsFlat = if partsFlatStr.isEmpty then Array.empty[Int] else partsFlatStr.split(',').map(_.toInt)
+  private[regex] def fromEncoded(nodesPart: String, partsFlatPart: String, charSets: IndexedSeq[CharSet]): Regex =
+    val nodeInts = nodesPart.split(',').map(_.toInt)
+    val partsFlat = if partsFlatPart.isEmpty then Array.empty[Int] else partsFlatPart.split(',').map(_.toInt)
 
     val n = nodeInts.length / 4
     val nodes = new Array[Regex](n)
     var i = 0
     while i < n do
-      val tag = nodeInts(i * 4)
       val arg1 = nodeInts(i * 4 + 1)
       val arg2 = nodeInts(i * 4 + 2)
       val arg3 = nodeInts(i * 4 + 3)
-      nodes(i) = tag match
-        case EpsTag => Eps
-        case EmptyTag => Empty
-        case StartAnchorTag => StartAnchor
-        case CharsTag => Chars(charSets(arg1))
-        case ConcatTag => Concat(nodes(arg1), nodes(arg2))
-        case StarTag => Star(nodes(arg1))
-        case ComplTag => Compl(nodes(arg1))
-        case LookTag => Look(nodes(arg1), arg2 != 0)
-        case RepeatTag => Repeat(nodes(arg1), arg2, arg3)
-        case AltTag | InterTag =>
+      nodes(i) = RegexTag.fromOrdinal(nodeInts(i * 4)) match
+        case RegexTag.Eps => Eps
+        case RegexTag.Empty => Empty
+        case RegexTag.StartAnchor => StartAnchor
+        case RegexTag.Chars => Chars(charSets(arg1))
+        case RegexTag.Concat => Concat(nodes(arg1), nodes(arg2))
+        case RegexTag.Star => Star(nodes(arg1))
+        case RegexTag.Compl => Compl(nodes(arg1))
+        case RegexTag.Look => Look(nodes(arg1), arg2 != 0)
+        case RegexTag.Repeat => Repeat(nodes(arg1), arg2, arg3)
+        case tag @ (RegexTag.Alt | RegexTag.Inter) =>
           var parts = Set.empty[Regex]
           var k = 0
           while k < arg2 do
             parts += nodes(partsFlat(arg1 + k))
             k += 1
-          if tag == AltTag then Alt(parts) else Inter(parts)
+          if tag == RegexTag.Alt then Alt(parts) else Inter(parts)
       i += 1
     nodes(n - 1)
 
@@ -429,9 +425,9 @@ object Regex:
       val charSets = mutable.ArrayBuffer.empty[CharSet]
       val steps = mutable.ArrayDeque(Enter(r))
 
-      def push(tag: Int, a: Int, b: Int, c: Int): Int =
+      def push(tag: RegexTag, a: Int, b: Int, c: Int): Int =
         val idx = tags.length
-        tags += tag
+        tags += tag.ordinal
         arg1 += a
         arg2 += b
         arg3 += c
@@ -444,13 +440,13 @@ object Regex:
           case Enter(node) if index.contains(node) => ()
           case Enter(node) =>
             node match
-              case Eps => index(node) = push(EpsTag, 0, 0, 0)
-              case Empty => index(node) = push(EmptyTag, 0, 0, 0)
-              case StartAnchor => index(node) = push(StartAnchorTag, 0, 0, 0)
+              case Eps => index(node) = push(RegexTag.Eps, 0, 0, 0)
+              case Empty => index(node) = push(RegexTag.Empty, 0, 0, 0)
+              case StartAnchor => index(node) = push(RegexTag.StartAnchor, 0, 0, 0)
               case Chars(set) =>
                 val csIdx = charSets.length
                 charSets += set
-                index(node) = push(CharsTag, csIdx, 0, 0)
+                index(node) = push(RegexTag.Chars, csIdx, 0, 0)
               case Concat(a, b) =>
                 steps += Exit(node)
                 enter(b)
@@ -475,28 +471,28 @@ object Regex:
                 parts.foreach(enter)
           case Exit(node) =>
             index(node) = node match
-              case Concat(a, b) => push(ConcatTag, index(a), index(b), 0)
-              case Star(inner) => push(StarTag, index(inner), 0, 0)
-              case Repeat(inner, lo, hi) => push(RepeatTag, index(inner), lo, hi)
-              case Compl(inner) => push(ComplTag, index(inner), 0, 0)
-              case Look(inner, positive) => push(LookTag, index(inner), if positive then 1 else 0, 0)
+              case Concat(a, b) => push(RegexTag.Concat, index(a), index(b), 0)
+              case Star(inner) => push(RegexTag.Star, index(inner), 0, 0)
+              case Repeat(inner, lo, hi) => push(RegexTag.Repeat, index(inner), lo, hi)
+              case Compl(inner) => push(RegexTag.Compl, index(inner), 0, 0)
+              case Look(inner, positive) => push(RegexTag.Look, index(inner), if positive then 1 else 0, 0)
               case Alt(parts) =>
                 val off = partsFlat.length
                 parts.foreach(p => partsFlat += index(p))
-                push(AltTag, off, parts.size, 0)
+                push(RegexTag.Alt, off, parts.size, 0)
               case Inter(parts) =>
                 val off = partsFlat.length
                 parts.foreach(p => partsFlat += index(p))
-                push(InterTag, off, parts.size, 0)
+                push(RegexTag.Inter, off, parts.size, 0)
               case leaf => throw MatchError(s"unreachable: leaf node $leaf pushed as Exit")
 
       val nodesPart = Iterator
         .range(0, tags.length)
         .flatMap(i => Iterator(tags(i), arg1(i), arg2(i), arg3(i)))
         .mkString(",")
-      val encoded = s"$nodesPart|${partsFlat.mkString(",")}"
+      val partsFlatPart = partsFlat.mkString(",")
       val charSetsExpr = Varargs(charSets.toSeq.map(Expr(_)))
-      '{ Regex.fromEncoded(${ Expr(encoded) }, IndexedSeq($charSetsExpr*)) }
+      '{ Regex.fromEncoded(${ Expr(nodesPart) }, ${ Expr(partsFlatPart) }, IndexedSeq($charSetsExpr*)) }
   // $COVERAGE-ON$
 
 extension [A, CC[X] <: Iterable[X]](xs: scala.collection.IterableOps[A, CC, CC[A]])

--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -331,9 +331,11 @@ object Regex:
   inline private val RepeatTag = 10
 
   /**
-   * Reconstructs a `Regex` from the flat encoding [[ToExpr]] produces: nodes laid out so every
-   * child index is smaller than its parent's, letting a single forward pass build each node from
-   * its already-built children with no recursion at all, on either side of this round trip.
+   * Reconstructs a `Regex` from the compact string [[ToExpr]] produces: `nodes|partsFlat`, where
+   * `nodes` is a `,`-joined `tag,arg1,arg2,arg3` quadruple per node (nodes laid out so every
+   * child index is smaller than its parent's) and `partsFlat` is a `,`-joined flat list of
+   * [[Alt]]/[[Inter]] children indices. A single forward pass then builds each node from its
+   * already-built children, with no recursion at all on either side of this round trip.
    *
    * `arg1`/`arg2`/`arg3` are reused across tags rather than given one array per case, since at
    * most three ints are ever needed per node:
@@ -343,49 +345,57 @@ object Regex:
    *  - [[Repeat]]: `arg1` = index of `r`; `arg2`/`arg3` = `lo`/`hi`.
    *  - [[Chars]]: `arg1` = index into `charSets`.
    *  - [[Alt]]/[[Inter]]: `arg1`/`arg2` = offset/count of this node's children within `partsFlat`.
+   *
+   * A single string, not the five parallel `Array[Int]` literals an earlier version of this used,
+   * because each element of an embedded array literal costs its own `dup`/`ldc`/`iastore`
+   * bytecode instructions - enough of them (e.g. from a long literal string; see [[ToExpr]]) hits
+   * the JVM's 64KB-per-method bytecode ceiling. A string constant is one `ldc` regardless of
+   * length, so the call site's bytecode size no longer scales with the source pattern's size at
+   * all; the only remaining limit is the classfile format's 65535-byte cap on a single constant.
    */
-  private[regex] def fromEncoded(
-    tags: Array[Int],
-    arg1: Array[Int],
-    arg2: Array[Int],
-    arg3: Array[Int],
-    partsFlat: Array[Int],
-    charSets: IndexedSeq[CharSet],
-  ): Regex =
-    val nodes = new Array[Regex](tags.length)
+  private[regex] def fromEncoded(encoded: String, charSets: IndexedSeq[CharSet]): Regex =
+    val bar = encoded.indexOf('|')
+    val nodeInts = encoded.substring(0, bar).split(',').map(_.toInt)
+    val partsFlatStr = encoded.substring(bar + 1)
+    val partsFlat = if partsFlatStr.isEmpty then Array.empty[Int] else partsFlatStr.split(',').map(_.toInt)
+
+    val n = nodeInts.length / 4
+    val nodes = new Array[Regex](n)
     var i = 0
-    while i < tags.length do
-      nodes(i) = tags(i) match
+    while i < n do
+      val tag = nodeInts(i * 4)
+      val arg1 = nodeInts(i * 4 + 1)
+      val arg2 = nodeInts(i * 4 + 2)
+      val arg3 = nodeInts(i * 4 + 3)
+      nodes(i) = tag match
         case EpsTag => Eps
         case EmptyTag => Empty
         case StartAnchorTag => StartAnchor
-        case CharsTag => Chars(charSets(arg1(i)))
-        case ConcatTag => Concat(nodes(arg1(i)), nodes(arg2(i)))
-        case StarTag => Star(nodes(arg1(i)))
-        case ComplTag => Compl(nodes(arg1(i)))
-        case LookTag => Look(nodes(arg1(i)), arg2(i) != 0)
-        case RepeatTag => Repeat(nodes(arg1(i)), arg2(i), arg3(i))
+        case CharsTag => Chars(charSets(arg1))
+        case ConcatTag => Concat(nodes(arg1), nodes(arg2))
+        case StarTag => Star(nodes(arg1))
+        case ComplTag => Compl(nodes(arg1))
+        case LookTag => Look(nodes(arg1), arg2 != 0)
+        case RepeatTag => Repeat(nodes(arg1), arg2, arg3)
         case AltTag | InterTag =>
-          val off = arg1(i)
-          val cnt = arg2(i)
           var parts = Set.empty[Regex]
           var k = 0
-          while k < cnt do
-            parts += nodes(partsFlat(off + k))
+          while k < arg2 do
+            parts += nodes(partsFlat(arg1 + k))
             k += 1
-          if tags(i) == AltTag then Alt(parts) else Inter(parts)
+          if tag == AltTag then Alt(parts) else Inter(parts)
       i += 1
-    nodes(tags.length - 1)
+    nodes(n - 1)
 
   /**
-   * Embeds the value's already-computed shape as flat `Array[Int]` tables reconstructed by
+   * Embeds the value's already-computed shape as a compact string reconstructed by
    * [[fromEncoded]], instead of regenerating it through the public smart constructors (`concat`,
-   * `alt`, `inter`, `star`, `unary_!`, `lookahead`) at every call site - the same approach
-   * [[TokenMatcher]]'s `ToExpr` uses to embed its DFA tables. The smart constructors exist to
-   * (re-)establish ACI normalization and merge `Chars` sets when building a tree from scratch; a
-   * `Regex` value reaching this `given` is already normalized, so re-running them at every macro
-   * call site - and again at every class load, since the generated code re-executes them - would
-   * just redo that work for a result that's already known.
+   * `alt`, `inter`, `star`, `unary_!`, `lookahead`) at every call site - the same spirit as
+   * [[TokenMatcher]]'s `ToExpr` embedding its DFA tables as plain data. The smart constructors
+   * exist to (re-)establish ACI normalization and merge `Chars` sets when building a tree from
+   * scratch; a `Regex` value reaching this `given` is already normalized, so re-running them at
+   * every macro call site - and again at every class load, since the generated code re-executes
+   * them - would just redo that work for a result that's already known.
    *
    * Splicing raw constructor calls one-per-node instead (as an earlier version of this `given`
    * did) still isn't enough on its own: `regex"..."` on a pattern producing a sufficiently deep
@@ -393,8 +403,11 @@ object Regex:
    * e.g. from a long literal string, since [[literal]] still builds one [[Concat]] node per
    * character - can `StackOverflowError` the *compiler itself* while it walks that many levels
    * of nested calls in a later phase (macro splicing, inlining), regardless of how carefully
-   * *this* macro was written. A flat array is embedded as a single call with no nesting, so no
-   * compiler pass has a deep tree to walk no matter how deep the source `Regex` is.
+   * *this* macro was written. Embedding as a single string is a single call with no nesting, so
+   * no compiler pass has a deep tree to walk no matter how deep the source `Regex` is - see
+   * [[fromEncoded]] for why a string beats parallel `Array[Int]` literals for that same call
+   * site's own bytecode size, which was still an (orthogonal, JVM-classfile-level) limit on a
+   * long enough pattern even after this fix's first version closed the stack-overflow.
    *
    * Both directions avoid recursion entirely: encoding below walks the tree with an explicit
    * `steps` stack (needed because, unlike [[halotukozak.commons.deepRecursive]]-trampolined
@@ -477,17 +490,13 @@ object Regex:
                 push(InterTag, off, parts.size, 0)
               case leaf => throw MatchError(s"unreachable: leaf node $leaf pushed as Exit")
 
+      val nodesPart = Iterator
+        .range(0, tags.length)
+        .flatMap(i => Iterator(tags(i), arg1(i), arg2(i), arg3(i)))
+        .mkString(",")
+      val encoded = s"$nodesPart|${partsFlat.mkString(",")}"
       val charSetsExpr = Varargs(charSets.toSeq.map(Expr(_)))
-      '{
-        Regex.fromEncoded(
-          ${ Expr(tags.toArray) },
-          ${ Expr(arg1.toArray) },
-          ${ Expr(arg2.toArray) },
-          ${ Expr(arg3.toArray) },
-          ${ Expr(partsFlat.toArray) },
-          IndexedSeq($charSetsExpr*),
-        )
-      }
+      '{ Regex.fromEncoded(${ Expr(encoded) }, IndexedSeq($charSetsExpr*)) }
   // $COVERAGE-ON$
 
 extension [A, CC[X] <: Iterable[X]](xs: scala.collection.IterableOps[A, CC, CC[A]])

--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -487,9 +487,8 @@ object Regex:
           case RegexTag.Look => Look(nodes(arg1), arg2 != 0)
           case RegexTag.Repeat => Repeat(nodes(arg1), arg2, arg3)
           case tag @ (RegexTag.Alt | RegexTag.Inter) =>
-            val parts = mutable.Set.empty[Regex]
-            (arg1 until arg1 + arg2).foreach(idx => parts += nodes(partsFlat(idx)))
-            if tag == RegexTag.Alt then Alt(parts.toSet) else Inter(parts.toSet)
+            val parts = (arg1 until arg1 + arg2).map(idx => nodes(partsFlat(idx))).toSet
+            if tag == RegexTag.Alt then Alt(parts) else Inter(parts)
         i += 1
       nodes(n - 1)
 

--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -488,10 +488,7 @@ object Regex:
           case RegexTag.Repeat => Repeat(nodes(arg1), arg2, arg3)
           case tag @ (RegexTag.Alt | RegexTag.Inter) =>
             val parts = mutable.Set.empty[Regex]
-            var k = 0
-            while k < arg2 do
-              parts += nodes(partsFlat(arg1 + k))
-              k += 1
+            (arg1 until arg1 + arg2).foreach(idx => parts += nodes(partsFlat(idx)))
             if tag == RegexTag.Alt then Alt(parts.toSet) else Inter(parts.toSet)
         i += 1
       nodes(n - 1)

--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -471,8 +471,7 @@ object Regex:
 
       val n = nodeInts.length / 4
       val nodes = new Array[Regex](n)
-      var i = 0
-      while i < n do
+      (0 until n).foreach { i =>
         val arg1 = nodeInts(i * 4 + 1)
         val arg2 = nodeInts(i * 4 + 2)
         val arg3 = nodeInts(i * 4 + 3)
@@ -489,7 +488,7 @@ object Regex:
           case tag @ (RegexTag.Alt | RegexTag.Inter) =>
             val parts = (arg1 until arg1 + arg2).map(idx => nodes(partsFlat(idx))).toSet
             if tag == RegexTag.Alt then Alt(parts) else Inter(parts)
-        i += 1
+      }
       nodes(n - 1)
 
   /**

--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -487,12 +487,12 @@ object Regex:
           case RegexTag.Look => Look(nodes(arg1), arg2 != 0)
           case RegexTag.Repeat => Repeat(nodes(arg1), arg2, arg3)
           case tag @ (RegexTag.Alt | RegexTag.Inter) =>
-            var parts = Set.empty[Regex]
+            val parts = mutable.Set.empty[Regex]
             var k = 0
             while k < arg2 do
               parts += nodes(partsFlat(arg1 + k))
               k += 1
-            if tag == RegexTag.Alt then Alt(parts) else Inter(parts)
+            if tag == RegexTag.Alt then Alt(parts.toSet) else Inter(parts.toSet)
         i += 1
       nodes(n - 1)
 

--- a/regex/Subset.scala
+++ b/regex/Subset.scala
@@ -111,6 +111,19 @@ object Subset:
         case Alt(parts) => Regex.alt(deriveAll(parts.toList, c, Nil))
         case Inter(parts) => Regex.inter(deriveAll(parts.toList, c, Nil))
         case s @ Star(inner) => inner.derive(c).concat(s)
+
+        /**
+         * Standard counting-automaton derivative rule, taken directly through the symbolic
+         * `Repeat` node instead of first unfolding it: `r{lo,hi} ≡ r · r{max(lo-1,0), hi-1}`
+         * (`r{0,hi} ≡ Eps | r{1,hi}` collapses to the same shape, since `D_c(Eps) = Empty` kills
+         * the "stop now" branch as soon as a character's actually been consumed). `hi` strictly
+         * decreases every step and bottoms out at `r.repeat(_, 0) == Eps` (see `Regex.repeat`),
+         * so this terminates the same way `Star`'s self-referential rule above does.
+         */
+        case Repeat(inner, lo, hi) =>
+          val newHi = if hi == Int.MaxValue then Int.MaxValue else hi - 1
+          inner.derive(c).concat(inner.repeat(math.max(lo - 1, 0), newHi))
+
         case Compl(inner) => !inner.derive(c)
 
         /** Zero-width: `L(Look(r, _)) ⊆ {ε}`, so no nonempty string can start it. */
@@ -191,6 +204,7 @@ object Subset:
         case Alt(parts) => Regex.alt(parts.map(stripStartAnchor))
         case Inter(parts) => Regex.inter(parts.map(stripStartAnchor))
         case Star(inner) => stripStartAnchor(inner).star
+        case Repeat(inner, lo, hi) => stripStartAnchor(inner).repeat(lo, hi)
         case Compl(inner) => !stripStartAnchor(inner)
         case Look(inner, positive) => Regex.lookahead(stripStartAnchor(inner), positive)
         case _ => r

--- a/test/RegexAlgebraTest.scala
+++ b/test/RegexAlgebraTest.scala
@@ -137,8 +137,16 @@ class RegexAlgebraTest extends munit.FunSuite:
     assertEquals(rA.repeat(1, 1), rA)
   }
 
-  test("repeat {n, MaxValue} ends with Star") {
-    assertEquals(rA.repeat(2, Int.MaxValue), rA.concat(rA).concat(rA.star))
+  test("repeat {lo,hi} is a single Repeat node, not lo/hi copies of the regex") {
+    rA.repeat(2, Int.MaxValue) match
+      case Repeat(r, 2, Int.MaxValue) => assertEquals(r, rA)
+      case other => fail(s"not Repeat(rA, 2, MaxValue): $other")
+  }
+
+  test("repeat {n, MaxValue} matches the same language as the unrolled concat+star form") {
+    val repeated = Subset.of(rA.repeat(2, Int.MaxValue))
+    val unrolled = Subset.of(rA.concat(rA).concat(rA.star))
+    assert(repeated.subset(unrolled) && unrolled.subset(repeated))
   }
 
   test("repeat rejects invalid bounds") {

--- a/test/RegexInterpolatorTest.scala
+++ b/test/RegexInterpolatorTest.scala
@@ -40,6 +40,35 @@ class RegexInterpolatorTest extends munit.FunSuite:
     assertEquals(regex"a{2,3}", RegexParser.parse("a{2,3}").toOption.get)
   }
 
+  // Regression for a real compiler crash (not just a slow compile). Two layers fixed this:
+  // `Regex.Repeat` keeps `{lo,hi}` symbolic instead of unfolding it into that many `Concat`/`Alt`
+  // nodes, and `ToExpr[Regex]` embeds any tree as flat `Array[Int]` tables (`Regex.fromEncoded`)
+  // instead of one nested constructor call per node. Either alone left a real crash: unfolding
+  // alone still recursed too deep encoding/splicing it, and flat-splicing alone doesn't help if
+  // `.repeat` still built a 1000-node tree to begin with. `regex"a{0,1000}"` reliably
+  // `StackOverflowError`'d the compiler before both landed - first inside `ToExpr[Regex]`'s own
+  // recursion, then, once that was made iterative, inside a *later* compiler phase (`Splicer`)
+  // walking the still-deep generated tree.
+  test("maximally deep quantifier compiles and round-trips without overflowing the compiler") {
+    assertEquals(regex"a{1000,1000}", RegexParser.parse("a{1000,1000}").toOption.get)
+    assertEquals(regex"a{0,1000}", RegexParser.parse("a{0,1000}").toOption.get)
+  }
+
+  // Regression: a long literal string builds one Concat node per character (Regex.literal
+  // folds right), independent of any {lo,hi} quantifier - so it stresses the same compiler-
+  // stack-safety concern from a different angle. 2000 chars comfortably exercises this without
+  // nearing the JVM's unrelated ~64KB-bytecode-per-method ceiling on the flat Array[Int] literals
+  // ToExpr[Regex] embeds - a hard classfile limit no macro-embedding strategy can lift, and not
+  // one this fix claims to.
+  test("long literal string compiles without overflowing the compiler") {
+    val long =
+      regex"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    assertEquals(
+      long,
+      Regex.literal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+    )
+  }
+
   test("groups") {
     assertEquals(regex"(a(bc))+", RegexParser.parse("(a(bc))+").toOption.get)
   }

--- a/test/RegexParserTest.scala
+++ b/test/RegexParserTest.scala
@@ -73,12 +73,12 @@ class RegexParserTest extends munit.FunSuite:
 
   test("parses bounded repetition {2}") {
     val a = Regex.lit('a')
-    assertEquals(parse("a{2}"), a.concat(a))
+    assertEquals(parse("a{2}"), a.repeat(2, 2))
   }
 
   test("parses unbounded repetition {2,}") {
     val a = Regex.lit('a')
-    assertEquals(parse("a{2,}"), a.concat(a).concat(a.star))
+    assertEquals(parse("a{2,}"), a.repeat(2, Int.MaxValue))
   }
 
   test("parses alternation") {


### PR DESCRIPTION
## Summary
- Fixes #34: `regex"..."` on a sufficiently deep pattern (e.g. a large `{lo,hi}` quantifier, or a long literal string) could `StackOverflowError` the compiler itself. Two changes close this:
  - `Regex.repeat` now keeps `{lo,hi}` as a single symbolic `Repeat(r, lo, hi)` node instead of unrolling it into that many `Concat`/`Alt` nodes (same approach as Rust's `regex-syntax` `Hir`), extending `nullable`/`alphabetBoundaries`/`hasStartAnchor` and adding a Brzozowski derivative rule for it. This also drops `.repeat`'s runtime allocation from O(hi) to O(1).
  - `ToExpr[Regex]` is split into `RegexEncoder`/`RegexDecoder`: a pure, macro-free encode/decode pair that embeds the tree as two compact strings + a `CharSet` list (walked with an explicit stack on both sides, no recursion), so the splice site's generated code is O(1) in size regardless of source pattern depth - avoiding both a compiler-stack-overflow in later phases (`Splicer`/inlining) and the JVM's 64KB-per-method bytecode ceiling that plain `Array[Int]` literals hit.

(#33's fix - embedding raw constructors instead of re-running the smart constructors - already landed on `main` via #58.)

## Test plan
- [x] Full existing test suite passes (`scala-cli test . --exclude "bench/**"`)
- [x] Added regression tests for the reported crash (`a{1000,1000}`, `a{0,1000}`, a 2000-char literal string) in `RegexInterpolatorTest`
- [x] Manually reproduced the pre-fix `StackOverflowError` in a worktree at the old commit to confirm the regression tests actually exercise the bug
- [x] Updated `RegexParserTest`/`RegexAlgebraTest` assertions that depended on the old unrolled `{lo,hi}` representation