### PR TITLE
Guard isEmpty/subset/compile against unbounded state-space blowup

### DIFF
--- a/regex/Subset.scala
+++ b/regex/Subset.scala
@@ -6,6 +6,8 @@ import halotukozak.regex.Regex.{Empty, Eps, *}
 import scala.annotation.tailrec
 import scala.collection.immutable.{Queue, SortedSet}
 import scala.quoted.{Expr, Quotes, ToExpr}
+import scala.util.boundary
+import scala.util.boundary.break
 
 /**
  * Opaque view over a [[Regex]] exposing Brzozowski-derivative based language emptiness
@@ -16,6 +18,23 @@ import scala.quoted.{Expr, Quotes, ToExpr}
  * derivative state set finite up to similarity.
  */
 opaque type Subset = Regex
+
+/**
+ * Raised (as a `Left`, never thrown) by [[Subset.isEmptyBounded]], [[Subset.subsetBounded]],
+ * [[TokenMatcher.fromRegexesBounded]], and [[TokenMatcher.fromSubsetsBounded]] when deciding the
+ * answer would require visiting more than `limit` distinct derivative states.
+ *
+ * This engine has no classic backtracking, so it isn't exposed to catastrophic-backtracking
+ * ReDoS in the traditional sense - but the derivative state space these operations explore has
+ * no bound of its own: a pattern built to maximize distinct derivative states (many overlapping
+ * alternations/intersections/bounded repetitions near [[Regex.maxRepeatBound]]) can still make
+ * either slow or memory-heavy. That matters wherever pattern strings come from untrusted input,
+ * e.g. `Subset`'s stated use case of validating one pattern against another at load/build time.
+ * The bounded methods this guards are opt-in: the plain `isEmpty`/`subset`/`fromRegexes`/
+ * `fromSubsets` stay uncapped, unchanged, for every existing caller.
+ */
+final case class StateSpaceLimitExceeded(limit: Int):
+  override def toString: String = s"derivative state-space limit ($limit distinct states) exceeded"
 
 object Subset:
 
@@ -38,6 +57,15 @@ object Subset:
     /** `true` iff `L(a) ⊆ L(b)`. */
     def subset(b: Subset): Boolean = (a & !b).isEmpty
 
+    /**
+     * Like [[subset]], but fails fast with [[StateSpaceLimitExceeded]] instead of letting the
+     * underlying [[isEmptyBounded]] BFS visit more than `maxStates` distinct derivative states -
+     * see [[StateSpaceLimitExceeded]] for why that matters on untrusted patterns.
+     */
+    def subsetBounded(b: Subset, maxStates: Int): Either[StateSpaceLimitExceeded, Boolean] = (a & !b).isEmptyBounded(
+      maxStates,
+    )
+
     /** `true` iff `L(a) ⊆ L(b)` and `L(a) ≠ L(b)`. */
     def properSubset(b: Subset): Boolean = a.subset(b) && !b.subset(a)
 
@@ -54,6 +82,27 @@ object Subset:
               loop(rest.enqueueAll(next), visited ++ next)
 
       loop(Queue(a), Set(a))
+
+    /**
+     * Like [[isEmpty]], but fails fast with `Left(StateSpaceLimitExceeded(maxStates))` the
+     * moment the BFS would need to have visited more than `maxStates` distinct derivative
+     * states to keep going, instead of exploring an unbounded number of them. Opt-in guard for
+     * callers deciding emptiness/subset (see [[subsetBounded]]) of a pattern that may come from
+     * untrusted input - see [[StateSpaceLimitExceeded]].
+     */
+    def isEmptyBounded(maxStates: Int): Either[StateSpaceLimitExceeded, Boolean] = boundary:
+      @tailrec def loop(queue: Queue[Regex], visited: Set[Regex]): Boolean =
+        if visited.size > maxStates then break(Left(StateSpaceLimitExceeded(maxStates)))
+        queue.dequeueOption match
+          case None => true
+          case Some((s, rest)) =>
+            if s.nullable then false
+            else
+              val derived = deriveAt(partitionReps(s), 0, s, Nil)
+              val next = derived.filterNot(visited.contains)
+              loop(rest.enqueueAll(next), visited ++ next)
+
+      Right(loop(Queue(a), Set(a)))
 
     /** `true` iff `ε ∈ L(a)`. */
     def nullable: Boolean = a.nullable

--- a/regex/TokenMatcher.scala
+++ b/regex/TokenMatcher.scala
@@ -3,6 +3,8 @@ package halotukozak.regex
 import scala.annotation.{publicInBinary, tailrec}
 import scala.collection.immutable.{Queue, SortedSet}
 import scala.quoted.{Expr, Quotes, ToExpr}
+import scala.util.boundary
+import scala.util.boundary.break
 
 /**
  * Lexer-style longest-match tokenizer over a priority-ordered list of patterns.
@@ -75,51 +77,70 @@ object TokenMatcher:
   def fromRegexes(initial: Regex*): TokenMatcher = fromSubsets(initial.map(Subset.of)*)
 
   /** Build a matcher from pre-parsed subsets (use this from macros after compile-time parsing). */
-  def fromSubsets(initial: Subset*): TokenMatcher = compile(initial)
+  def fromSubsets(initial: Subset*): TokenMatcher =
+    compile(initial, Int.MaxValue).getOrElse(throw MatchError("unreachable: Int.MaxValue state cap exceeded"))
 
-  private def compile(patterns: Seq[Subset]): TokenMatcher =
-    val boundaries = SortedSet(0, CharSet.maxCodePoint + 1)
-      .concat(patterns.iterator.flatMap(_.underlying.alphabetBoundaries))
-      .init
-      .toArray
+  /**
+   * Like [[fromRegexes]], but fails fast with `Left(StateSpaceLimitExceeded(maxStates))` instead
+   * of exploring more than `maxStates` distinct derivative states while building the DFA - see
+   * [[StateSpaceLimitExceeded]]. Opt-in: [[fromRegexes]] itself stays uncapped for existing
+   * callers.
+   */
+  def fromRegexesBounded(maxStates: Int)(initial: Regex*): Either[StateSpaceLimitExceeded, TokenMatcher] =
+    fromSubsetsBounded(maxStates)(initial.map(Subset.of)*)
 
-    def isDead(state: Seq[Subset]): Boolean = state.forall(_ == Subset.empty)
+  /** Like [[fromSubsets]], but capped the way [[fromRegexesBounded]] caps [[fromRegexes]]. */
+  def fromSubsetsBounded(maxStates: Int)(initial: Subset*): Either[StateSpaceLimitExceeded, TokenMatcher] =
+    compile(initial, maxStates)
 
-    /**
-     * Derives `state` across every alphabet partition, assigning a fresh id (via `ids`) to any
-     * not-yet-seen resulting state. `discovered` lists those newly-seen states, in partition
-     * order, for the caller to enqueue for later exploration.
-     */
-    def deriveRow(
-      state: Seq[Subset],
-      ids: Map[Seq[Subset], Int],
-    ): (row: Vector[Int], ids: Map[Seq[Subset], Int], discovered: List[Seq[Subset]]) =
-      boundaries.indices.foldLeft((row = Vector.empty[Int], ids = ids, discovered = List.empty[Seq[Subset]])):
-        case ((row, ids, discovered), i) =>
-          val next = state.map(_.derive(boundaries(i)))
-          if isDead(next) then (row = row :+ -1, ids = ids, discovered = discovered)
-          else
-            ids.get(next) match
-              case Some(id) => (row = row :+ id, ids = ids, discovered = discovered)
-              case None =>
-                val id = ids.size
-                (row = row :+ id, ids = ids.updated(next, id), discovered = discovered :+ next)
+  private def compile(patterns: Seq[Subset], maxStates: Int): Either[StateSpaceLimitExceeded, TokenMatcher] =
+    boundary:
+      val boundaries = SortedSet(0, CharSet.maxCodePoint + 1)
+        .concat(patterns.iterator.flatMap(_.underlying.alphabetBoundaries))
+        .init
+        .toArray
 
-    @tailrec
-    def loop(
-      queue: Queue[Seq[Subset]],
-      ids: Map[Seq[Subset], Int],
-      transitions: Vector[Int],
-      accept: Vector[Int],
-    ): (transitions: Array[Int], accept: Array[Int]) =
-      queue.dequeueOption match
-        case None => (transitions = transitions.toArray, accept = accept.toArray)
-        case Some((state, rest)) =>
-          val (row, newIds, discovered) = deriveRow(state, ids)
-          loop(rest.enqueueAll(discovered), newIds, transitions ++ row, accept :+ firstNullable(state))
+      def isDead(state: Seq[Subset]): Boolean = state.forall(_ == Subset.empty)
 
-    val (transitions, accept) = loop(Queue(patterns), Map(patterns -> 0), Vector.empty, Vector.empty)
-    new TokenMatcher(boundaries, transitions, accept)
+      /**
+       * Derives `state` across every alphabet partition, assigning a fresh id (via `ids`) to any
+       * not-yet-seen resulting state. `discovered` lists those newly-seen states, in partition
+       * order, for the caller to enqueue for later exploration. `break`s out of the enclosing
+       * `compile` [[boundary]] the moment a discovery would push the visited-state count past
+       * `maxStates` - see [[StateSpaceLimitExceeded]].
+       */
+      def deriveRow(
+        state: Seq[Subset],
+        ids: Map[Seq[Subset], Int],
+      ): (row: Vector[Int], ids: Map[Seq[Subset], Int], discovered: List[Seq[Subset]]) =
+        boundaries.indices.foldLeft((row = Vector.empty[Int], ids = ids, discovered = List.empty[Seq[Subset]])):
+          case ((row, ids, discovered), i) =>
+            val next = state.map(_.derive(boundaries(i)))
+            if isDead(next) then (row = row :+ -1, ids = ids, discovered = discovered)
+            else
+              ids.get(next) match
+                case Some(id) => (row = row :+ id, ids = ids, discovered = discovered)
+                case None =>
+                  val id = ids.size
+                  if id >= maxStates then break(Left(StateSpaceLimitExceeded(maxStates)))
+                  (row = row :+ id, ids = ids.updated(next, id), discovered = discovered :+ next)
+
+      @tailrec
+      def loop(
+        queue: Queue[Seq[Subset]],
+        ids: Map[Seq[Subset], Int],
+        transitions: Vector[Int],
+        accept: Vector[Int],
+      ): (transitions: Array[Int], accept: Array[Int]) =
+        queue.dequeueOption match
+          case None => (transitions = transitions.toArray, accept = accept.toArray)
+          case Some((state, rest)) =>
+            val (row, newIds, discovered) = deriveRow(state, ids)
+            loop(rest.enqueueAll(discovered), newIds, transitions ++ row, accept :+ firstNullable(state))
+
+      if maxStates < 1 then break(Left(StateSpaceLimitExceeded(maxStates)))
+      val (transitions, accept) = loop(Queue(patterns), Map(patterns -> 0), Vector.empty, Vector.empty)
+      Right(new TokenMatcher(boundaries, transitions, accept))
 
   private def firstNullable(state: Seq[Subset]): Int =
     state.iterator.zipWithIndex.collectFirst { case (sub, idx) if sub.nullable => idx }.getOrElse(-1)

--- a/test/SubsetTest.scala
+++ b/test/SubsetTest.scala
@@ -180,3 +180,35 @@ class SubsetTest extends munit.FunSuite:
     assertEquals(s("abc").underlying, Regex.literal("abc"))
     assertEquals(Subset.of(Eps).underlying, Eps)
   }
+
+  // isEmptyBounded / subsetBounded -----------------------------------------
+
+  // Neither operand is a bare `Chars` node, so the smart constructors can't collapse this to
+  // `Empty` at construction time (same reasoning as `disjointIntersection` in
+  // `SubsetBenchmark`) - `isEmpty`'s BFS genuinely has to walk derivative states across the
+  // whole `[a-z]*` middle section before concluding the language is empty, so it's a case that
+  // needs more than a couple of visited states to decide either way.
+  private lazy val disjointIntersection = s(s("a[a-z]*b").underlying & s("a[a-z]*c").underlying)
+
+  test("isEmptyBounded agrees with isEmpty once the cap is generous enough") {
+    assertEquals(disjointIntersection.isEmptyBounded(10_000), Right(disjointIntersection.isEmpty))
+    assertEquals(s("a").isEmptyBounded(10_000), Right(s("a").isEmpty))
+  }
+
+  test("isEmptyBounded fails fast, without exploring further, once the cap is too small") {
+    assertEquals(disjointIntersection.isEmptyBounded(1), Left(StateSpaceLimitExceeded(1)))
+  }
+
+  test("isEmptyBounded(0) always fails: even the start state alone exceeds a zero cap") {
+    assertEquals(s(Empty).isEmptyBounded(0), Left(StateSpaceLimitExceeded(0)))
+    assertEquals(s(Empty).isEmptyBounded(1), Right(true))
+  }
+
+  test("subsetBounded agrees with subset once the cap is generous enough") {
+    assertEquals(s("a").subsetBounded(s("[a-z]"), 10_000), Right(true))
+    assertEquals(s("[a-z]").subsetBounded(s("a"), 10_000), Right(false))
+  }
+
+  test("subsetBounded fails fast once the cap is too small") {
+    assert(disjointIntersection.subsetBounded(s(Empty), 1).isLeft)
+  }

--- a/test/TokenMatcherTest.scala
+++ b/test/TokenMatcherTest.scala
@@ -238,3 +238,35 @@ class TokenMatcherTest extends munit.FunSuite:
     val m = matcher("[0-9][_0-9]*[Uu]?[Ll]?\\.\\.", "[0-9][_0-9]*[Uu]?[Ll]?")
     assertEquals(m.matchAt("1..10", 0), Some((priority = 0, end = 3)))
   }
+
+  // fromRegexesBounded / fromSubsetsBounded --------------------------------
+
+  test("fromRegexesBounded agrees with fromRegexes once the cap is generous enough") {
+    val bounded = TokenMatcher.fromRegexesBounded(10_000)(parse("if"), parse("[a-zA-Z_][a-zA-Z0-9_]*"))
+    assert(bounded.isRight)
+    assertEquals(bounded.toOption.get.matchAt("ifx", 0), matcher("if", "[a-zA-Z_][a-zA-Z0-9_]*").matchAt("ifx", 0))
+  }
+
+  test("fromRegexesBounded fails fast once the cap is too small to build even the start state") {
+    assertEquals(TokenMatcher.fromRegexesBounded(0)(parse("[a-zA-Z_][a-zA-Z0-9_]*")), Left(StateSpaceLimitExceeded(0)))
+  }
+
+  // A 100-way alternation of distinct fixed-length tokens builds a sizeable prefix-trie of DFA
+  // states (same idea as `manyStatesEmpty` in `SubsetBenchmark`) - enough states that a cap of 1
+  // is exceeded well before `compile` finishes, but a generous cap still succeeds.
+  private lazy val manyStatesPattern = (0 until 100).map(i => Regex.literal(f"token$i%03d")).reduce(_ | _)
+
+  test("fromRegexesBounded stays well-behaved (no exponential blowup) on a wide alternation") {
+    assertEquals(TokenMatcher.fromRegexesBounded(1)(manyStatesPattern), Left(StateSpaceLimitExceeded(1)))
+    assert(TokenMatcher.fromRegexesBounded(10_000)(manyStatesPattern).isRight)
+  }
+
+  // Classic ReDoS-shaped input: `(a|aa)*b` would catastrophically backtrack in a backtracking
+  // engine. This engine has no backtracking, but the derivative-based state space it explores
+  // instead has no bound of its own without an explicit cap - this asserts building a DFA from
+  // several such patterns, combined and negated, stays within a modest cap instead of blowing up.
+  test("fromRegexesBounded stays well-behaved on classic ReDoS-shaped patterns combined/negated") {
+    val redosLike = parse("(a|aa)*b")
+    val combined = redosLike.concat(redosLike) | !redosLike
+    assert(TokenMatcher.fromRegexesBounded(1_000)(redosLike, combined).isRight)
+  }


### PR DESCRIPTION
## Summary
- Adds opt-in, capped variants — `Subset.isEmptyBounded`/`subsetBounded` and `TokenMatcher.fromRegexesBounded`/`fromSubsetsBounded` — that fail fast with a new `StateSpaceLimitExceeded` error once the derivative-based BFS would visit more distinct states than a caller-supplied `maxStates`, instead of exploring an unbounded state space.
- Existing uncapped `isEmpty`/`subset`/`fromRegexes`/`fromSubsets` are untouched, so no existing caller is affected.
- Uses `scala.util.boundary`/`break` (already used elsewhere in the codebase) to short-circuit out of the nested BFS/DFA-construction helpers as soon as the cap is hit.

Closes #54.

## Test plan
- [x] `scala-cli --power test . --exclude "bench/**"` — all suites pass (JVM)
- [x] Same test run under `--js-version 1.22.0` and `--native-version 0.5.12` — all pass
- [x] `scala-cli --power fmt --check .` — clean
- [x] `scala-cli --power doc . --exclude "bench/**"` — builds, no new warnings
- [x] New unit tests cover: cap-too-small vs. cap-generous-enough for both `Subset` and `TokenMatcher`, plus a regression test building a DFA from `(a|aa)*b`-style (classic ReDoS-shaped) patterns, combined and negated, confirming it stays within a modest state cap

https://claude.ai/code/session_01LeS7LLTm9XDo2AmdS36NsX