### PR TITLE
Extract capture-group spans via a Pike's-VM NFA engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,22 @@ back to parsing at runtime and throws `IllegalArgumentException` on failure inst
 `${...}` splices aren't currently supported — only the literal parts of the string are used, so
 `regex"a${x}b"` parses as `"ab"`, ignoring `x`.
 
+### Capturing group spans
+
+`CaptureMatcher` extracts the spans matched by `(...)`/`(?<name>...)` groups from a whole-string
+match, backed by a no-backtracking NFA engine (see its own scaladoc for why this is a separate
+engine from `Subset`/`TokenMatcher`, not an extension of either):
+
+```scala
+import halotukozak.regex.CaptureMatcher
+
+val date = CaptureMatcher.parse("(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})").toOption.get
+val result = date.matchWhole("2026-08-27").get
+
+result.group("year") // Some((start = 0, end = 4))
+result.group(1) // same span, by number instead of name
+```
+
 ## Status
 
 Early (`0.x`). The parser deliberately supports a subset of `java.util.regex.Pattern`'s syntax —

--- a/bench/CaptureBenchmark.scala
+++ b/bench/CaptureBenchmark.scala
@@ -1,0 +1,48 @@
+package halotukozak.regex
+
+import org.openjdk.jmh.annotations.*
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Benchmarks for [[CaptureMatcher]]'s Pike's-VM NFA engine — a new, isolated hot path (see its
+ * own doc comment), not a regression check against [[Subset]]/[[TokenMatcher]] since it doesn't
+ * touch either. Just a baseline for this feature: `compile` cost, straightforward `matchWhole`
+ * cost, and a many-alternations/many-groups case that empirically confirms the priority-ordered
+ * thread simulation's per-PC dedup keeps the live thread count bounded rather than blowing up.
+ *
+ * Run: `scala-cli run --jmh . -- CaptureBenchmark` (see `bench/README.md`).
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+class CaptureBenchmark:
+
+  private val emailPattern = """([a-zA-Z0-9._%+-]+)@([a-zA-Z0-9.-]+)\.([a-zA-Z]{2,})"""
+  private val emailInput = "user@example.com"
+
+  private def matcherOf(pattern: String): CaptureMatcher = CaptureMatcher.parse(pattern) match
+    case Right(m) => m
+    case Left(err) => throw IllegalStateException(s"benchmark pattern failed to parse: $err")
+
+  private val emailMatcher = matcherOf(emailPattern)
+
+  @Benchmark
+  def compileEmailPattern(): CaptureMatcher = matcherOf(emailPattern)
+
+  @Benchmark
+  def matchWholeSimple(): Option[MatchResult] = emailMatcher.matchWhole(emailInput)
+
+  // A 50-way alternation of distinct fixed-length tokens, each capturing, followed by a shared
+  // suffix - every branch is a live thread until the first character disambiguates them (they
+  // all start with a distinct literal, so they die immediately in practice, but this still
+  // stresses the epsilon-closure/Split-chain machinery's per-step bookkeeping at a size where an
+  // accidental O(n^2) (e.g. from rebuilding the visited array or thread vector inefficiently)
+  // would show up). Meant to be directly comparable to SubsetBenchmark's manyStatesEmpty, which
+  // stresses the analogous BFS in Subset's derivative engine.
+  private val manyGroupsPattern = (0 until 50).map(i => f"(tok$i%03d)").mkString("|") + "(x*)"
+  private val manyGroupsMatcher = matcherOf(manyGroupsPattern)
+  private val manyGroupsInput = "tok049" + ("x" * 20)
+
+  @Benchmark
+  def matchWholeManyAlternations(): Option[MatchResult] = manyGroupsMatcher.matchWhole(manyGroupsInput)

--- a/regex/Capture.scala
+++ b/regex/Capture.scala
@@ -1,0 +1,317 @@
+package halotukozak.regex
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+/**
+ * Result of a successful [[CaptureMatcher.matchWhole]] call: the spans captured by every
+ * numbered/named group in the pattern (see [[Regex.Group]]). Group 0 is always present and
+ * always spans the whole input, exactly like `java.util.regex.Matcher.group(0)`.
+ */
+final case class MatchResult private[regex] (private val registers: Array[Int], private val names: Map[String, Int]):
+
+  /**
+   * The span `(start, end)` captured by group `index`, or [[None]] if that group never
+   * participated in the match - e.g. it sits in an alternative branch that wasn't taken, or
+   * inside a `*`/`{0,n}` repetition that ran zero times. Distinct from `Some((p, p))`, which
+   * means the group *did* participate but captured zero characters (e.g. `(a?)` matching `""`) -
+   * see [[Regex.Group]]'s own doc comment for why this distinction matters.
+   */
+  def group(index: Int): Option[(start: Int, end: Int)] =
+    val s = registers(2 * index)
+    val e = registers(2 * index + 1)
+    if s < 0 || e < 0 then None else Some((start = s, end = e))
+
+  /** Like [[group]], but by a `(?<name>...)` group's name instead of its number. */
+  def group(name: String): Option[(start: Int, end: Int)] = names.get(name).flatMap(group)
+
+/**
+ * Whole-string capture-span extraction for patterns containing [[Regex.Group]] nodes - the
+ * "Phase B" this library's issue #18 tracks (Phase A, [[Regex.Group]] itself, only recognizes
+ * groups structurally; nothing extracted their matched spans until this).
+ *
+ * Backed by Pike's VM: a Thompson-construction NFA compiled directly from a parsed [[Regex]]
+ * tree (unerased - unlike [[Subset.of]], this needs every [[Regex.Group]] node, not none of
+ * them), executed as a priority-ordered set of "threads" (one per live NFA position) that all
+ * advance one input code point at a time, each carrying its own capture-register array - the
+ * technique RE2/Go's `regexp`/Rust's `regex` crate actually ship for general (non-"one-pass")
+ * captures. Guaranteed `O(programSize × inputLength)`: at most one thread per program
+ * instruction survives each step (an equal-or-lower-priority duplicate reaching an
+ * already-live instruction is dropped), so there's no repeat of catastrophic-backtracking
+ * blowup - the same complexity discipline [[Subset.isEmpty]]'s visited-state BFS already
+ * relies on.
+ *
+ * This is a genuinely separate engine from [[Subset]]/[[TokenMatcher]], not an extension of
+ * either - `Subset.of` erases every `Group` before deriving through a pattern specifically so
+ * its derivative algebra never has to reason about captures at all. `Regex.scala`'s only
+ * changes for this feature are mechanical: [[Regex.Alt]]'s `parts` became an order-preserving
+ * `Vector` instead of a `Set` (see its own doc comment for why - every no-backtracking submatch
+ * algorithm, Pike's VM included, needs leftmost-first alternation priority, which a `Set`
+ * can't record) with `equals`/`hashCode` overridden back to Set-like semantics so `Subset`'s
+ * ACI-normalization/termination story is completely unaffected. `Subset.scala`/`TokenMatcher.scala`
+ * are untouched.
+ *
+ * Whole-string match only (mirrors this library's only existing matching precedent,
+ * `RegexConformanceTest`'s private `matches` helper) - no `find`/`replace`/`split`, and captures
+ * aren't wired into [[TokenMatcher]]'s compiled DFA. Both are tracked separately (issue #53 for
+ * the former; a `TokenMatcher` follow-up for the latter).
+ */
+final class CaptureMatcher private (
+  private val program: Array[CaptureMatcher.Inst],
+  private val entry: Int,
+  private val acceptPc: Int,
+  private val numRegisters: Int,
+  private val names: Map[String, Int],
+):
+  import CaptureMatcher.*
+
+  /** Matches `input` from start to end. [[None]] if the pattern doesn't accept the whole string. */
+  def matchWhole(input: CharSequence): Option[MatchResult] =
+    runToEnd(program, entry, acceptPc, numRegisters, input).map(MatchResult(_, names))
+
+object CaptureMatcher:
+
+  /** Parses `pattern` and compiles it into a [[CaptureMatcher]] ready for repeated matching. */
+  def parse(pattern: String): Either[RegexParseError, CaptureMatcher] =
+    RegexParser.parse(pattern).map(compile)
+
+  private def compile(r: Regex): CaptureMatcher =
+    val names = collectNames(r)
+    val compiler = new NfaCompiler
+    val acceptPc = compiler.emit(Inst.Match)
+    val closeWhole = compiler.emit(Inst.Save(1, acceptPc))
+    val bodyEntry = compiler.compile(r, closeWhole)
+    val entry = compiler.emit(Inst.Save(0, bodyEntry))
+    new CaptureMatcher(compiler.toProgram, entry, acceptPc, 2 * (numGroups(r) + 1), names)
+
+  private def numGroups(r: Regex): Int =
+    @tailrec def loop(pending: List[Regex], best: Int): Int = pending match
+      case Nil => best
+      case Regex.Group(index, _, inner) :: rest => loop(inner :: rest, math.max(best, index))
+      case Regex.Concat(a, b) :: rest => loop(a :: b :: rest, best)
+      case Regex.Alt(parts) :: rest => loop(parts.toList ::: rest, best)
+      case Regex.Inter(parts) :: rest => loop(parts.toList ::: rest, best)
+      case Regex.Star(inner) :: rest => loop(inner :: rest, best)
+      case Regex.Repeat(inner, _, _) :: rest => loop(inner :: rest, best)
+      case Regex.Compl(inner) :: rest => loop(inner :: rest, best)
+      case Regex.Look(inner, _) :: rest => loop(inner :: rest, best)
+      case (Regex.Eps | Regex.Empty | Regex.Chars(_) | Regex.StartAnchor) :: rest => loop(rest, best)
+    loop(List(r), 0)
+
+  private def collectNames(r: Regex): Map[String, Int] = r match
+    case Regex.Group(index, Some(name), inner) => collectNames(inner) + (name -> index)
+    case Regex.Group(_, None, inner) => collectNames(inner)
+    case Regex.Concat(a, b) => collectNames(a) ++ collectNames(b)
+    case Regex.Alt(parts) => parts.iterator.map(collectNames).foldLeft(Map.empty)(_ ++ _)
+    case Regex.Inter(parts) => parts.iterator.map(collectNames).foldLeft(Map.empty)(_ ++ _)
+    case Regex.Star(inner) => collectNames(inner)
+    case Regex.Repeat(inner, _, _) => collectNames(inner)
+    case Regex.Compl(inner) => collectNames(inner)
+    case Regex.Look(inner, _) => collectNames(inner)
+    case Regex.Eps | Regex.Empty | Regex.Chars(_) | Regex.StartAnchor => Map.empty
+
+  // ---------------------------------------------------------------------------------------
+  // NFA compilation - Pike's VM bytecode (Cox, "Regular Expression Matching: the Virtual
+  // Machine Approach"), extended with Save for captures. Compiled continuation-passing style:
+  // `compile(node, next)` emits node's own instructions ending in a fall-through to the
+  // already-known `next` PC, returning node's entry PC - so composition (Concat, Group, ...)
+  // just threads PCs, no backpatching, EXCEPT Star/Repeat's self-referential loop-back Split,
+  // which reserves its slot before compiling the loop body and patches it once the body's
+  // entry PC is known.
+  // ---------------------------------------------------------------------------------------
+
+  private enum Inst:
+    /** Consume one code point in `set`, advance to `next`. Dies (thread removed) otherwise. */
+    case Char(set: CharSet, next: Int)
+
+    /**
+     * Zero-width: `^`/`\A`. `$`/`\Z`/`\z` need no equivalent - they're parsed as `(?!.)`
+     * ([[RegexParser]]'s `endOfInput`), handled by [[Look]] below like any other lookahead.
+     */
+    case StartAssert(next: Int)
+
+    /** Zero-width: record the current input position into register `slot`. */
+    case Save(slot: Int, next: Int)
+
+    /** Zero-width fork: `x` is tried first (higher priority) - see [[epsilonClosure]]. */
+    case Split(x: Int, next: Int)
+
+    /**
+     * Zero-width lookahead assertion. `entry`/`acceptPc` compile the lookahead body as its own
+     * nested sub-program (sharing the outer program's instruction array) - not delegated to
+     * [[Subset]], since `Subset` has no notion of captures at all and a group nested inside a
+     * lookahead (`(?=(?<x>a))a`) must still capture correctly.
+     */
+    case Look(entry: Int, acceptPc: Int, positive: Boolean, next: Int)
+
+    /** Terminal: reached this instruction's own PC. See [[epsilonClosure]] for what that means. */
+    case Match
+
+  private final class NfaCompiler:
+    private val buf = mutable.ArrayBuffer.empty[Inst]
+
+    def toProgram: Array[Inst] = buf.toArray
+
+    def emit(inst: Inst): Int =
+      buf += inst
+      buf.length - 1
+
+    private def reserve(): Int = emit(Inst.StartAssert(-1))
+
+    private def patch(pc: Int, inst: Inst): Unit = buf(pc) = inst
+
+    def compile(node: Regex, next: Int): Int = node match
+      case Regex.Eps => next
+      case Regex.Empty => emit(Inst.Char(CharSet.empty, next)) // matches nothing: any char dies here
+      case Regex.Chars(set) => emit(Inst.Char(set, next))
+      case Regex.StartAnchor => emit(Inst.StartAssert(next))
+      case Regex.Concat(a, b) => compile(a, compile(b, next))
+      case Regex.Alt(parts) => compileAlt(parts.toList, next)
+      case Regex.Star(inner) => compileStar(inner, next)
+      case Regex.Repeat(inner, lo, hi) => compileRepeat(inner, lo, hi, next)
+      case Regex.Group(index, _, inner) =>
+        val closePc = emit(Inst.Save(2 * index + 1, next))
+        emit(Inst.Save(2 * index, compile(inner, closePc)))
+      case Regex.Look(inner, positive) =>
+        val acceptPc = emit(Inst.Match)
+        val innerEntry = compile(inner, acceptPc)
+        emit(Inst.Look(innerEntry, acceptPc, positive, next))
+      case Regex.Compl(_) | Regex.Inter(_) =>
+        // Never produced by RegexParser.parse (`&&`/`[^...]` stay at the CharSet level - see
+        // RegexParser.scala; Inter/Compl are only ever built programmatically, e.g. by Subset's
+        // own `&`/`!`), so CaptureMatcher.parse's input can't contain either.
+        throw MatchError(s"unreachable: CaptureMatcher doesn't support $node (never produced by RegexParser.parse)")
+
+    private def compileAlt(branches: List[Regex], next: Int): Int = branches match
+      case Nil => throw MatchError("unreachable: Alt always has >= 2 branches")
+      case single :: Nil => compile(single, next)
+      case head :: tail =>
+        val headEntry = compile(head, next)
+        val restEntry = compileAlt(tail, next)
+        emit(Inst.Split(headEntry, restEntry))
+
+    private def compileStar(inner: Regex, next: Int): Int =
+      val splitPc = reserve()
+      val innerEntry = compile(inner, splitPc)
+      patch(splitPc, Inst.Split(innerEntry, next))
+      splitPc
+
+    private def compileRepeat(inner: Regex, lo: Int, hi: Int, next: Int): Int =
+      if hi == Int.MaxValue then compileMandatory(inner, lo, compileStar(inner, next))
+      else compileBounded(inner, lo, hi, next)
+
+    private def compileBounded(inner: Regex, lo: Int, hi: Int, next: Int): Int =
+      @tailrec def optionalTail(remaining: Int, tail: Int): Int =
+        if remaining <= 0 then tail
+        else
+          val splitPc = reserve()
+          val innerEntry = compile(inner, tail)
+          patch(splitPc, Inst.Split(innerEntry, tail))
+          optionalTail(remaining - 1, splitPc)
+      compileMandatory(inner, lo, optionalTail(hi - lo, next))
+
+    @tailrec
+    private def compileMandatory(inner: Regex, remaining: Int, next: Int): Int =
+      if remaining <= 0 then next else compileMandatory(inner, remaining - 1, compile(inner, next))
+
+  // ---------------------------------------------------------------------------------------
+  // Runtime - the priority-ordered thread simulation itself. `epsilonClosure` is shared by
+  // both the outer whole-string driver (`runToEnd`, which only inspects `accepted` once all
+  // input is consumed) and lookahead evaluation (`evalLookahead`, which inspects it after
+  // every step, per Look's "some prefix" semantics) - see Inst.Look's doc comment for why
+  // lookahead needs its own nested simulation instead of delegating to Subset.
+  // ---------------------------------------------------------------------------------------
+
+  private final case class ClosureResult(charThreads: Vector[(Int, Array[Int])], accepted: Option[Array[Int]])
+
+  /**
+   * Epsilon-closure of `starts` at input position `pos`: follows every zero-width instruction
+   * (`Save`/`Split`/`StartAssert`/`Look`) to the `Char`/`Match` instructions reachable from
+   * them, in priority order (each `Split`'s `x` fully explored before its `next`), visiting each
+   * program counter at most once - a lower-priority thread reaching an already-visited PC is
+   * simply dropped, since (Cox) "the saved pointers do not influence future execution: they only
+   * record past execution." That's both what bounds one step's work to `O(programSize)` and what
+   * implements leftmost-first disambiguation.
+   */
+  private def epsilonClosure(
+    program: Array[Inst],
+    starts: Iterable[(Int, Array[Int])],
+    pos: Int,
+    input: CharSequence,
+    acceptPc: Int,
+  ): ClosureResult =
+    val visited = new Array[Boolean](program.length)
+    val charThreads = mutable.ArrayBuffer.empty[(Int, Array[Int])]
+    var accepted: Option[Array[Int]] = None
+
+    def go(pc: Int, registers: Array[Int]): Unit =
+      if !visited(pc) then
+        visited(pc) = true
+        program(pc) match
+          case _: Inst.Char => charThreads += ((pc, registers))
+          case Inst.Match => if pc == acceptPc && accepted.isEmpty then accepted = Some(registers)
+          case Inst.Save(slot, next) =>
+            val updated = registers.clone()
+            updated(slot) = pos
+            go(next, updated)
+          case Inst.Split(x, next) =>
+            go(x, registers)
+            go(next, registers)
+          case Inst.StartAssert(next) => if pos == 0 then go(next, registers)
+          case Inst.Look(entry, lookAcceptPc, positive, next) =>
+            evalLookahead(program, entry, lookAcceptPc, input, pos, registers) match
+              case Some(withCaptures) if positive => go(next, withCaptures)
+              case None if !positive => go(next, registers)
+              case _ => ()
+
+    starts.foreach(go)
+    ClosureResult(charThreads.toVector, accepted)
+
+  private def stepChar(program: Array[Inst], charThreads: Vector[(Int, Array[Int])], c: Int)
+    : Vector[(Int, Array[Int])] =
+    charThreads.flatMap: (pc, registers) =>
+      program(pc) match
+        case Inst.Char(set, next) if set.contains(c) => Some((next, registers))
+        case _ => None
+
+  /**
+   * `(?=r)`/`(?!r)`: "some prefix of the string remaining here is in `L(r)`" (see [[Regex.Look]]'s
+   * doc), i.e. accept as soon as `acceptPc` is reached at *any* position, not just at end of
+   * input - unlike [[runToEnd]]'s whole-string semantics. Bounded by the remaining input length,
+   * same as the outer match.
+   */
+  private def evalLookahead(
+    program: Array[Inst],
+    entry: Int,
+    acceptPc: Int,
+    input: CharSequence,
+    startPos: Int,
+    initialRegisters: Array[Int],
+  ): Option[Array[Int]] =
+    @tailrec def loop(threads: Iterable[(Int, Array[Int])], pos: Int): Option[Array[Int]] =
+      val closure = epsilonClosure(program, threads, pos, input, acceptPc)
+      closure.accepted match
+        case some @ Some(_) => some
+        case None =>
+          if closure.charThreads.isEmpty || pos >= input.length then None
+          else
+            val c = Character.codePointAt(input, pos)
+            loop(stepChar(program, closure.charThreads, c), pos + Character.charCount(c))
+    loop(List((entry, initialRegisters)), startPos)
+
+  /** Whole-string match: only `accepted` at the final position (`pos == input.length`) counts. */
+  private def runToEnd(
+    program: Array[Inst],
+    entry: Int,
+    acceptPc: Int,
+    numRegisters: Int,
+    input: CharSequence,
+  ): Option[Array[Int]] =
+    @tailrec def loop(threads: Iterable[(Int, Array[Int])], pos: Int): Option[Array[Int]] =
+      val closure = epsilonClosure(program, threads, pos, input, acceptPc)
+      if pos >= input.length then closure.accepted
+      else if closure.charThreads.isEmpty then None
+      else
+        val c = Character.codePointAt(input, pos)
+        loop(stepChar(program, closure.charThreads, c), pos + Character.charCount(c))
+    loop(List((entry, Array.fill(numRegisters)(-1))), 0)

--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -84,8 +84,23 @@ enum Regex:
   /** Concatenation `a · b`. */
   case Concat private[Regex] (a: Regex, b: Regex)
 
-  /** Alternation. Stored as a [[Set]] for ACI normalization. Always size ≥ 2. */
-  case Alt private[Regex] (parts: Set[Regex])
+  /**
+   * Alternation. Always size ≥ 2. `parts` is an [[AltBranches]], not a plain [[Set]] like
+   * [[Inter]]: it still needs Set-like equality/hashing for ACI normalization (two `Alt`s built
+   * from the same branches must be `==` and hash identically regardless of order, or
+   * `Subset.isEmpty`'s visited-state dedup - and the finite-derivative-state-space guarantee it
+   * relies on - would silently stop collapsing equivalent states) - see [[AltBranches]]'s own
+   * `equals`/`hashCode`. But *iteration* order matters too, unlike `Inter`: it's a pattern's only
+   * record of alternation branch priority (`a|b` prefers `a`), which every no-backtracking
+   * submatch algorithm needs for leftmost-first disambiguation (see `Capture.scala`) and which
+   * nothing before that ever needed to preserve. `Regex.alt`/`|` build it in exactly the order
+   * they're given (deduplicated, first occurrence kept) rather than normalizing it away.
+   *
+   * (A Scala 3 enum case can't carry its own `equals`/`hashCode` override directly - only plain
+   * classes can - hence `AltBranches` being a separate wrapper type instead of `Alt`'s stored
+   * field simply being an order-preserving `Vector[Regex]` with the override inline.)
+   */
+  case Alt private[Regex] (parts: AltBranches)
 
   /** Intersection. Stored as a [[Set]] for ACI normalization. Always size ≥ 2. */
   case Inter private[Regex] (parts: Set[Regex])
@@ -207,8 +222,8 @@ enum Regex:
     case Look(r, _) => r.hasStartAnchor
     case Group(_, _, inner) => inner.hasStartAnchor
 
-  /** Alternation: `this | other`. */
-  infix def |(other: Regex): Regex = Regex.alt(Set(this, other))
+  /** Alternation: `this | other`, preferring `this` - see [[Regex.Alt]]'s doc comment. */
+  infix def |(other: Regex): Regex = Regex.alt(Vector(this, other))
 
   /** Intersection: `this ∩ other`. */
   infix def &(other: Regex): Regex = Regex.inter(Set(this, other))
@@ -249,6 +264,33 @@ enum Regex:
       case _ if lo == 1 && hi == 1 => this
       case _ => Regex.Repeat(this, lo, hi)
 
+/**
+ * [[Regex.Alt]]'s branch container - see its doc comment for why this exists instead of `Alt`
+ * simply storing a `Vector[Regex]`/`Set[Regex]` directly. Stores two genuinely immutable views
+ * built together, once, from the same order-preserving dedup pass: `toVector` (insertion-order,
+ * deduplicated - what `iterator` and every inherited `Iterable` operation like `exists`/`map`/
+ * `toList` use) and `asSet` (the same elements, for `equals`/`hashCode` - Set semantics are
+ * order-independent, so ACI normalization and `Subset.isEmpty`'s visited-state dedup are
+ * unaffected by which order two equivalent `Alt`s happen to store their branches in). The
+ * `mutable.LinkedHashSet` doing the actual dedup work in [[AltBranches.apply]] below is a
+ * construction-time-only local builder, discarded once `toVector`/`asSet` are snapshotted from
+ * it - `AltBranches` itself holds no mutable state, matching every other node in this immutable
+ * tree (see `Regex`'s own cached `hashCode` above, which relies on that immutability).
+ */
+final class AltBranches private[regex] (override val toVector: Vector[Regex], private val asSet: Set[Regex])
+  extends Iterable[Regex]:
+  def iterator: Iterator[Regex] = toVector.iterator
+
+  override def equals(that: Any): Boolean = that match
+    case that: AltBranches => asSet == that.asSet
+    case _ => false
+  override lazy val hashCode: Int = asSet.hashCode
+
+private[regex] object AltBranches:
+  def apply(xs: IterableOnce[Regex]): AltBranches =
+    val deduped = mutable.LinkedHashSet.from(xs)
+    new AltBranches(deduped.toVector, deduped.toSet)
+
 object Regex:
 
   extension (a: Regex)
@@ -272,24 +314,31 @@ object Regex:
 
   def apply(set: CharSet): Regex = if set.isEmpty then Empty else Chars(set)
 
-  /** Alternation of a collection. */
+  /**
+   * Alternation of a collection, preferring earlier elements - see [[Regex.Alt]]'s doc comment.
+   * Builds `flat` straight into an [[AltBranches]] (order-preserving dedup, one pass) instead of
+   * `.toVector.distinct` followed by a separate `.toSet` later for `equals`/`hashCode`: the
+   * latter would build two different set-like views of the same elements where one suffices.
+   */
   def alt(parts: Iterable[Regex]): Regex =
-    val flat = parts.iterator
-      .flatMap:
-        case Alt(p) => p
-        case Empty => Iterator.empty
-        case r => Iterator.single(r)
-      .toSet
+    val flat = AltBranches(parts.iterator.flatMap {
+      case Alt(p) => p
+      case Empty => Iterator.empty
+      case r => Iterator.single(r)
+    })
     if flat.isEmpty then Empty
     else if flat.sizeIs == 1 then flat.head
     else
-      val (chars, rest) = flat.partitionIsInstance[Chars]
-      val merged: Set[Regex] =
-        if chars.sizeIs <= 1 then flat
-        else
-          val union = chars.iterator.map(_.set).foldLeft(CharSet.empty)(_ union _)
-          if union.isEmpty then rest else rest + Chars(union)
-      if merged.sizeIs == 1 then merged.head else Alt(merged)
+      val (chars, rest) = flat.toVector.partitionIsInstance[Chars]
+      // Where the merged Chars node lands among `rest` doesn't affect priority: two bare Chars
+      // alternatives (no Group inside - a Group would make this a Group node, not a Chars leaf)
+      // can never differ in captures, and a single input position can only ever satisfy one of
+      // them anyway, so which "wins" is unobservable either way.
+      if chars.sizeIs <= 1 then Alt(flat)
+      else
+        val union = chars.iterator.map(_.set).foldLeft(CharSet.empty)(_ union _)
+        val merged = if union.isEmpty then rest else rest :+ Chars(union)
+        if merged.sizeIs == 1 then merged.head else Alt(AltBranches(merged))
 
   /** Intersection of a collection. */
   def inter(parts: Iterable[Regex]): Regex =
@@ -545,9 +594,13 @@ object Regex:
           case RegexTag.Look => Look(nodes(arg1), arg2 != 0)
           case RegexTag.Repeat => Repeat(nodes(arg1), arg2, arg3)
           case RegexTag.Group => Group(arg2, if arg3 < 0 then None else Some(groupNames(arg3)), nodes(arg1))
-          case tag @ (RegexTag.Alt | RegexTag.Inter) =>
-            val parts = (arg1 until arg1 + arg2).map(idx => nodes(partsFlat(idx))).toSet
-            if tag == RegexTag.Alt then Alt(parts) else Inter(parts)
+          case RegexTag.Alt =>
+            // Not `.toSet`: `encode` above lays `partsFlat` out in `Alt.parts`'s own order
+            // (`parts.foreach` over the now order-preserving `AltBranches`), so reading it back
+            // as an `IndexedSeq` naturally round-trips that order - see [[Regex.Alt]]'s doc.
+            Alt(AltBranches((arg1 until arg1 + arg2).map(idx => nodes(partsFlat(idx))).toVector))
+          case RegexTag.Inter =>
+            Inter((arg1 until arg1 + arg2).map(idx => nodes(partsFlat(idx))).toSet)
       }
       nodes(n - 1)
 

--- a/regex/RegexParser.scala
+++ b/regex/RegexParser.scala
@@ -278,7 +278,11 @@ object RegexParser:
             a.concat(a.star)
           case '?' =>
             pos += 1
-            Eps | a
+            // `a` first, not `Eps | a`: `Regex.alt`/`|` preserve the order they're given (see
+            // Regex.Alt's doc) precisely so a capture-aware consumer can tell "prefer entering
+            // `a`" (this quantifier's greedy default) from "prefer skipping it" - order that was
+            // unobservable before any such consumer existed, but is now load-bearing.
+            a | Eps
           case '{' =>
             pos += 1
             parseRepeat(a)

--- a/test/CaptureTest.scala
+++ b/test/CaptureTest.scala
@@ -1,0 +1,96 @@
+package halotukozak.regex
+
+class CaptureTest extends munit.FunSuite:
+
+  private def m(pattern: String): CaptureMatcher = CaptureMatcher.parse(pattern) match
+    case Right(matcher) => matcher
+    case Left(err) => fail(s"expected successful parse of /$pattern/, got $err")
+
+  private def matchOf(pattern: String, input: String): MatchResult =
+    m(pattern).matchWhole(input) match
+      case Some(result) => result
+      case None => fail(s"expected /$pattern/ to match \"$input\"")
+
+  // group spans
+
+  test("two sibling groups") {
+    val result = matchOf("(a)(b)", "ab")
+    assertEquals(result.group(1), Some((start = 0, end = 1)))
+    assertEquals(result.group(2), Some((start = 1, end = 2)))
+    assertEquals(result.group(0), Some((start = 0, end = 2)))
+  }
+
+  test("optional group that never participates is None, not a zero-width span") {
+    val result = matchOf("(a)?", "")
+    assertEquals(result.group(1), None)
+  }
+
+  test("group that participates and captures zero characters is Some((p,p)), not None") {
+    val result = matchOf("(a?)", "")
+    assertEquals(result.group(1), Some((start = 0, end = 0)))
+  }
+
+  test("alternation: only the taken branch's group is set") {
+    val result = matchOf("(a)|(b)", "b")
+    assertEquals(result.group(1), None)
+    assertEquals(result.group(2), Some((start = 0, end = 1)))
+  }
+
+  test("leftmost-first alternation priority (Cox's canonical a|ab example)") {
+    val result = matchOf("(a|ab)(c|bcd)(d*)", "abcd")
+    assertEquals(result.group(1), Some((start = 0, end = 1)))
+    assertEquals(result.group(2), Some((start = 1, end = 4)))
+    assertEquals(result.group(3), Some((start = 4, end = 4)))
+  }
+
+  test("group inside a star keeps only the last iteration's span") {
+    val result = matchOf("((a)(b))*", "abab")
+    assertEquals(result.group(1), Some((start = 2, end = 4)))
+    assertEquals(result.group(2), Some((start = 2, end = 3)))
+    assertEquals(result.group(3), Some((start = 3, end = 4)))
+  }
+
+  test("group inside a star that runs zero times is None") {
+    val result = matchOf("(a)*", "")
+    assertEquals(result.group(1), None)
+  }
+
+  test("named groups resolve to the right indices") {
+    val result = matchOf("(?<year>\\d{4})-(?<month>\\d{2})", "2026-08")
+    assertEquals(result.group("year"), Some((start = 0, end = 4)))
+    assertEquals(result.group("month"), Some((start = 5, end = 7)))
+    assertEquals(result.group("year"), result.group(1))
+    assertEquals(result.group("month"), result.group(2))
+  }
+
+  test("group nested inside a lookahead still captures") {
+    val result = matchOf("(?=(?<x>a))a", "a")
+    assertEquals(result.group("x"), Some((start = 0, end = 1)))
+    assertEquals(result.group(0), Some((start = 0, end = 1)))
+  }
+
+  test("negative lookahead never contributes captures") {
+    val result = matchOf("(?!(?<x>b))a", "a")
+    assertEquals(result.group("x"), None)
+  }
+
+  // whole-string match semantics
+
+  test("no match returns None") {
+    assertEquals(m("(a)(b)").matchWhole("ac"), None)
+    assertEquals(m("(a)(b)").matchWhole("a"), None)
+    assertEquals(m("(a)(b)").matchWhole("abc"), None)
+  }
+
+  test("bounded repetition on a group") {
+    val result = matchOf("(ab){2,3}", "ababab")
+    assertEquals(result.group(1), Some((start = 4, end = 6)))
+  }
+
+  // parse errors
+
+  test("parse error surfaces as Left") {
+    CaptureMatcher.parse("(a") match
+      case Left(_) => ()
+      case Right(_) => fail("expected a parse error for an unterminated group")
+  }

--- a/test/RegexAlgebraTest.scala
+++ b/test/RegexAlgebraTest.scala
@@ -42,7 +42,7 @@ class RegexAlgebraTest extends munit.FunSuite:
     val sB = rB.star
     val sC = rC.star
     sA | sB | sC match
-      case Alt(parts) => assertEquals(parts, Set(sA, sB, sC))
+      case Alt(parts) => assertEquals(parts.toSet, Set(sA, sB, sC))
       case other => fail(s"not flattened Alt: $other")
   }
 


### PR DESCRIPTION
## Summary

Phase B for #18, building on Phase A (#66, `Regex.Group`): patterns with capturing/named groups now have their matched spans extractable via `CaptureMatcher.parse(pattern).matchWhole(input)`.

**Updated approach (see commit history):** the first version of this PR compiled from a separate, hand-written order-preserving `OrderedRegex` parse tree, duplicating most of `RegexParser`'s structural grammar to work around `Regex.Alt`'s `Set`-based branch storage losing alternation order. On review, that redundancy wasn't worth it - the real fix is upstream:

1. **`refactor(Regex): make Alt.parts order-preserving via AltBranches`** - `Regex.Alt` now stores its branches in a new `AltBranches` wrapper (an order-preserving `Vector` with `equals`/`hashCode` overridden back to Set-like semantics), instead of a plain `Set`. This is exactly right for `Subset`'s order-independent containment questions (ACI normalization, still fully preserved) while also finally recording the one thing every no-backtracking submatch algorithm needs: alternation branch priority (`a|b` prefers `a`, matching Perl/PCRE/RE2/Go/Rust, not POSIX-longest). `Subset.scala`/`TokenMatcher.scala` need zero changes - confirmed by the full existing test suite passing unchanged, plus a `SubsetBenchmark`/`RegexBenchmark` smoke run showing no regression on this now-touched hot path.
2. **`feat(Capture): extract capture-group spans via a Pike's-VM NFA engine`** - with `Alt` order now recoverable, `CaptureMatcher` compiles a Pike's-VM NFA (`Save`/`Split`/`Char`/`Look`/`Match` instructions, priority-ordered thread simulation with per-PC dedup - the technique RE2/Go/Rust ship for general captures) **directly from the ordinary `Regex` tree** `RegexParser.parse` already produces - no separate parser, no parallel AST. `RegexParser.scala` is completely untouched by this commit.
3. **`docs+bench(Capture)`** - JMH coverage + a README quickstart section.

Lookahead assertions still run as their own nested sub-simulation sharing the outer thread's registers, rather than delegating to `Subset` (which has no notion of captures at all), so a group nested inside a lookahead (`(?=(?<x>a))a`) still captures correctly.

Whole-string match only (mirrors this library's only existing matching precedent, `RegexConformanceTest`'s private `matches` helper) - no `find`/`replace`/`split` (issue #53) and no `TokenMatcher` DFA integration, both tracked separately.

## Test plan

- [x] 13 tests in `test/CaptureTest.scala` covering the classic hard submatch cases: leftmost-first alternation priority (Cox's canonical `(a|ab)(c|bcd)(d*)` example), last-iteration-wins for a group inside a star, the `None`-vs-`Some((p,p))` empty-vs-never-participated distinction, named-group resolution, and captures inside both positive and negative lookahead
- [x] Full existing test suite passes unchanged (`scala-cli --power test . --exclude "bench/**"`)
- [x] `scala-cli --power fmt --check .` clean
- [x] JVM + Scala.js compile clean; Scala Native not locally verifiable (missing toolchain artifact in this environment, confirmed pre-existing on the base branch too) - CI has the real toolchain
- [x] `SubsetBenchmark`/`RegexBenchmark` smoke run (the `Alt` refactor touches shared code) - no regression
- [x] New `bench/CaptureBenchmark.scala` (compile cost, straightforward match, 50-way-alternation stress case) - smoke-tested locally, no pathological thread-count blowup

Note: history was rewritten (force-pushed) to fold the design change in cleanly rather than leave the now-obsolete `OrderedRegex` scaffolding as dead intermediate commits - the existing review comment predates this and describes the earlier version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)