### PR TITLE
Support case myMatcher(g1, g2) => ... via unapplySeq

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,15 @@ result.group("year") // Some((start = 0, end = 4))
 result.group(1) // same span, by number instead of name
 ```
 
+`CaptureMatcher` also works as a `case` pattern (`unapplySeq`), one element per numbered group,
+`None` for a group that didn't participate rather than `scala.util.matching.Regex`'s `null`:
+
+```scala
+"2026-08-27" match
+  case date(year, month, day) => println(s"$year/$month/$day")
+  case _ => println("no match")
+```
+
 ## Status
 
 Early (`0.x`). The parser deliberately supports a subset of `java.util.regex.Pattern`'s syntax —

--- a/regex/Capture.scala
+++ b/regex/Capture.scala
@@ -65,9 +65,25 @@ final class CaptureMatcher private (
 ):
   import CaptureMatcher.*
 
+  private def numGroups: Int = numRegisters / 2 - 1
+
   /** Matches `input` from start to end. [[None]] if the pattern doesn't accept the whole string. */
   def matchWhole(input: CharSequence): Option[MatchResult] =
     runToEnd(program, entry, acceptPc, numRegisters, input).map(MatchResult(_, names))
+
+  /**
+   * Lets a `CaptureMatcher` be used as a pattern-match extractor - `case myMatcher(g1, g2) =>
+   * ...` - mirroring `scala.util.matching.Regex`'s own `unapplySeq`, except a group that never
+   * participated in the match comes back as [[None]] rather than `scala.util.matching.Regex`'s
+   * `null`-in-a-`List` (see [[MatchResult.group]] for why that distinction exists - the same
+   * reasoning applies here). Positional only, one element per numbered group `1..N` - group 0
+   * (the whole match) is never included, the same convention `scala.util.matching.Regex` uses -
+   * `MatchResult.group(name)` (via [[matchWhole]]) still covers named-group access, which
+   * `unapplySeq`'s purely positional binding can't express.
+   */
+  def unapplySeq(input: CharSequence): Option[Seq[Option[String]]] =
+    matchWhole(input).map: result =>
+      (1 to numGroups).map(i => result.group(i).map(span => input.subSequence(span.start, span.end).toString))
 
 object CaptureMatcher:
 

--- a/test/CaptureTest.scala
+++ b/test/CaptureTest.scala
@@ -94,3 +94,27 @@ class CaptureTest extends munit.FunSuite:
       case Left(_) => ()
       case Right(_) => fail("expected a parse error for an unterminated group")
   }
+
+  // unapplySeq - `case myMatcher(g1, g2) => ...`, per issue #52
+
+  test("unapplySeq lets a CaptureMatcher be used as a case pattern") {
+    val date = m("""(\d{4})-(\d{2})-(\d{2})""")
+    "2026-08-27" match
+      case date(year, month, day) => assertEquals((year, month, day), (Some("2026"), Some("08"), Some("27")))
+      case _ => fail("expected the date pattern to match")
+  }
+
+  test("unapplySeq: non-participating group is None, not null-in-a-List like scala.util.matching.Regex") {
+    val m2 = m("(a)|(b)")
+    "b" match
+      case m2(g1, g2) => assertEquals((g1, g2), (None, Some("b")))
+      case _ => fail("expected the alternation to match")
+  }
+
+  test("unapplySeq: no match is None, doesn't throw") {
+    assertEquals(m("(a)(b)").unapplySeq("ac"), None)
+  }
+
+  test("unapplySeq excludes group 0 (the whole match), same convention as scala.util.matching.Regex") {
+    assertEquals(m("(a)(b)").unapplySeq("ab"), Some(Seq(Some("a"), Some("b"))))
+  }


### PR DESCRIPTION
Closes #52.

Stacked on #67 (needs `CaptureMatcher` to exist first).

## Summary

Adds `CaptureMatcher.unapplySeq(input): Option[Seq[Option[String]]]` so a `CaptureMatcher` can be used directly as a pattern-match extractor, the way `scala.util.matching.Regex` already can:

```scala
val date = CaptureMatcher.parse("""(\d{4})-(\d{2})-(\d{2})""").toOption.get
"2026-08-27" match
  case date(year, month, day) => println(s"$year/$month/$day")
  case _ => println("no match")
```

Per #52's own framing ("attach to `Regex`/`Subset` directly, or to a distinct macro-produced type that knows its own group count/names, mirroring `TokenMatcher`") this attaches to `CaptureMatcher` - which already is that distinct type, built in #67 - rather than `Regex`/`Subset`. No new algorithm: `unapplySeq` is a thin adapter over the already-tested `matchWhole`/`MatchResult.group`, one element per numbered group (`1..N`, group 0 excluded, matching `scala.util.matching.Regex`'s own convention).

Deliberately **not** `scala.util.matching.Regex`-compatible in one respect: a group that never participated comes back as `None` in the `Seq`, not `null` smuggled into a `List` - consistent with `MatchResult.group`'s own `None`-vs-`Some((p,p))` distinction, and avoids reproducing a known stdlib wart.

No macro, no compile-time-validated arity checking, and no `Regex`-level convenience shortcut that would silently recompile the NFA per call - all deliberately out of scope for this pass; `CaptureMatcher.parse` already gives a cheap way to build one matcher and reuse it.

## Test plan

- [x] 4 new tests in `test/CaptureTest.scala`: real `case myMatcher(...) =>` usage, the `None`-vs-`null` distinction on a non-participating group, no-match returns `None` without throwing, group 0 excluded
- [x] Full test suite passes (`scala-cli --power test . --exclude "bench/**" --exclude "scripts/**"`)
- [x] `scala-cli --power fmt --check .` clean
- [x] JVM + Scala.js compile clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)