### PR TITLE
fix(ci): degrade benchmark-vs-main gracefully when bench/ outpaces main

### DIFF
--- a/.github/scripts/compare_benchmarks.py
+++ b/.github/scripts/compare_benchmarks.py
@@ -20,9 +20,20 @@ def bench_key(entry: dict) -> str:
     return f'{entry["benchmark"]}[{param_str}]'
 
 
-def load(path: str) -> dict[str, dict]:
-    with open(path) as f:
-        entries = json.load(f)
+def load(path: str) -> dict[str, dict] | None:
+    """Returns None (rather than raising) when the file is missing or empty - the
+    "Run benchmarks on main" CI step uses continue-on-error and can legitimately not
+    produce a result file, e.g. when the PR's bench/ harness references an API that
+    only exists on the PR's own branch. The caller renders that as an explicit
+    "baseline unavailable" note instead of crashing this comparison outright."""
+    try:
+        with open(path) as f:
+            content = f.read().strip()
+    except FileNotFoundError:
+        return None
+    if not content:
+        return None
+    entries = json.loads(content)
     return {bench_key(e): e for e in entries}
 
 
@@ -35,6 +46,18 @@ def main() -> None:
     baseline_path, candidate_path = sys.argv[1], sys.argv[2]
     baseline = load(baseline_path)
     candidate = load(candidate_path)
+    if candidate is None:
+        print(f"⚠️ No results for the current branch at `{candidate_path}` - nothing to report.")
+        return
+    baseline_available = baseline is not None
+    if not baseline_available:
+        print(
+            "⚠️ No `main` baseline to compare against - the bench/ harness on this PR likely "
+            "references an API that doesn't exist on `main` yet (a new benchmark for new "
+            "functionality, or an updated signature for a perf change), so benchmarking `main` "
+            "with it didn't compile. Showing this branch's numbers on their own instead:\n"
+        )
+        baseline = {}
     names = sorted(set(baseline) | set(candidate))
 
     print("| Benchmark | main | current | Δ |")
@@ -68,13 +91,14 @@ def main() -> None:
 
         print(f"| `{short_name}` | {fmt_score(base)} | {fmt_score(cand)} | {marker} {pct:+.1f}% |")
 
-    print()
-    print(
-        f"Δ is candidate vs. `main`; positive means the metric's value grew "
-        f"(slower for time-based benchmarks, faster for throughput ones). "
-        f"🔴/🟢 mark a ≥{REGRESSION_THRESHOLD_PCT:.0f}% regression/improvement — "
-        f"informational only, single-sample on a shared runner, not a merge gate."
-    )
+    if baseline_available:
+        print()
+        print(
+            f"Δ is candidate vs. `main`; positive means the metric's value grew "
+            f"(slower for time-based benchmarks, faster for throughput ones). "
+            f"🔴/🟢 mark a ≥{REGRESSION_THRESHOLD_PCT:.0f}% regression/improvement — "
+            f"informational only, single-sample on a shared runner, not a merge gate."
+        )
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,14 @@ jobs:
           -f 1 -wi 3 -i 5 -w 300ms -r 300ms -rf json -rff "$GITHUB_WORKSPACE/current-bench.json"
       - name: Run benchmarks on main
         # Reuses the PR's bench/ harness (and project.scala, for identical compiler
-        # settings) against main's library sources, so only regex/ actually differs.
+        # settings) against main's library sources, so only regex/ actually differs -
+        # *except* when the PR itself changes an API its own bench/ exercises (a new
+        # benchmark for new functionality, a changed signature for a perf change): main
+        # doesn't have that change yet, so this step's compile can legitimately fail.
+        # That's not a bug in the PR, just this comparison being inapplicable to it -
+        # continue-on-error keeps that non-fatal, matching this job's informational-only
+        # status; Compare below degrades to current-branch-only numbers when it happens.
+        continue-on-error: true
         run: |
           git worktree add /tmp/main-baseline origin/main
           rm -rf /tmp/main-baseline/bench


### PR DESCRIPTION
## Problem

`Benchmark (current vs main)` copies the PR's `bench/` directory onto a `git worktree` of
`origin/main`'s library sources and compiles+runs it there, on the stated assumption that
"only `regex/` actually differs" between the two.

That assumption breaks whenever a PR's `bench/` exercises an API that only exists on the
PR's own branch — a new benchmark added for new functionality, or an existing benchmark's
signature updated to match a perf-motivated API change. `main` doesn't have that change yet,
so the copied `bench/` fails to compile against it. The job then reports `fail`, even though
its own comment already documents it as "informational only... not a merge gate" — a
container-scoped compile error in an unrelated comparison step shouldn't override that.

Confirmed as the exact cause on two currently-open PRs, both otherwise fully green:
- **#67**: `bench/CaptureBenchmark.scala` references the new `CaptureMatcher`, not on `main`.
- **#70**: `TokenMatcher.matchAt`'s signature changed (`Option[...]` → `... | Null`) for a
  perf improvement, and the benchmark was updated to match — but `main` still has the old
  signature.

## Fix

- Mark the "Run benchmarks on main" step `continue-on-error: true`, so a compile failure
  there (comparison inapplicable to this PR) doesn't fail the job.
- `compare_benchmarks.py`: treat a missing/empty main-side result file as "no baseline
  available" instead of crashing on `json.load` — prints an explanatory note and falls back
  to showing the current branch's numbers on their own.

Verified locally: normal comparison, missing baseline file, empty baseline file, and missing
candidate file all produce sensible Markdown output rather than a traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)