### PR TITLE
refactor(Subset,Capture): fold deriveAll/eraseGroupsAll into deepRecursive .map

### DIFF
--- a/regex/Capture.scala
+++ b/regex/Capture.scala
@@ -114,17 +114,21 @@ object CaptureMatcher:
       case (Regex.Eps | Regex.Empty | Regex.Chars(_) | Regex.StartAnchor) :: rest => loop(rest, best)
     loop(List(r), 0)
 
-  private def collectNames(r: Regex): Map[String, Int] = r match
-    case Regex.Group(index, Some(name), inner) => collectNames(inner) + (name -> index)
-    case Regex.Group(_, None, inner) => collectNames(inner)
-    case Regex.Concat(a, b) => collectNames(a) ++ collectNames(b)
-    case Regex.Alt(parts) => parts.iterator.map(collectNames).foldLeft(Map.empty)(_ ++ _)
-    case Regex.Inter(parts) => parts.iterator.map(collectNames).foldLeft(Map.empty)(_ ++ _)
-    case Regex.Star(inner) => collectNames(inner)
-    case Regex.Repeat(inner, _, _) => collectNames(inner)
-    case Regex.Compl(inner) => collectNames(inner)
-    case Regex.Look(inner, _) => collectNames(inner)
-    case Regex.Eps | Regex.Empty | Regex.Chars(_) | Regex.StartAnchor => Map.empty
+  /** Like [[numGroups]]: a plain `@tailrec` worklist loop, for the same stack-safety reason. */
+  private def collectNames(r: Regex): Map[String, Int] =
+    @tailrec def loop(pending: List[Regex], acc: Map[String, Int]): Map[String, Int] = pending match
+      case Nil => acc
+      case Regex.Group(index, Some(name), inner) :: rest => loop(inner :: rest, acc + (name -> index))
+      case Regex.Group(_, None, inner) :: rest => loop(inner :: rest, acc)
+      case Regex.Concat(a, b) :: rest => loop(a :: b :: rest, acc)
+      case Regex.Alt(parts) :: rest => loop(parts.toList ::: rest, acc)
+      case Regex.Inter(parts) :: rest => loop(parts.toList ::: rest, acc)
+      case Regex.Star(inner) :: rest => loop(inner :: rest, acc)
+      case Regex.Repeat(inner, _, _) :: rest => loop(inner :: rest, acc)
+      case Regex.Compl(inner) :: rest => loop(inner :: rest, acc)
+      case Regex.Look(inner, _) :: rest => loop(inner :: rest, acc)
+      case (Regex.Eps | Regex.Empty | Regex.Chars(_) | Regex.StartAnchor) :: rest => loop(rest, acc)
+    loop(List(r), Map.empty)
 
   // ---------------------------------------------------------------------------------------
   // NFA compilation - Pike's VM bytecode (Cox, "Regular Expression Matching: the Virtual
@@ -198,13 +202,23 @@ object CaptureMatcher:
         // own `&`/`!`), so CaptureMatcher.parse's input can't contain either.
         throw MatchError(s"unreachable: CaptureMatcher doesn't support $node (never produced by RegexParser.parse)")
 
-    private def compileAlt(branches: List[Regex], next: Int): Int = branches match
-      case Nil => throw MatchError("unreachable: Alt always has >= 2 branches")
-      case single :: Nil => compile(single, next)
-      case head :: tail =>
-        val headEntry = compile(head, next)
-        val restEntry = compileAlt(tail, next)
-        emit(Inst.Split(headEntry, restEntry))
+    /**
+     * A plain `@tailrec` loop, not `deepRecursive`: recursion depth here tracks branch *count*,
+     * not tree depth (an `Alt` isn't capped the way `Regex.repeat` caps `Repeat` bounds, so a
+     * pattern spelling out enough `|`-separated branches needs the same stack safety `compile`'s
+     * tree recursion does) - but unlike that one, this shape flattens for free: walking
+     * `branches.reverse` and folding `Split`s from the lowest-priority branch backward builds
+     * the exact same nested-`Split` structure the natural `head :: compileAlt(tail, next)`
+     * recursion would (`Split(b1, Split(b2, ..., Split(bn-1, bn)))`), just accumulated instead
+     * of nested - so there's no `deepRecursive` dispatch cost to pay per branch either.
+     */
+    private def compileAlt(branches: List[Regex], next: Int): Int =
+      @tailrec def loop(remaining: List[Regex], acc: Int): Int = remaining match
+        case Nil => acc
+        case head :: rest => loop(rest, emit(Inst.Split(compile(head, next), acc)))
+      branches.reverse match
+        case Nil => throw MatchError("unreachable: Alt always has >= 2 branches")
+        case last :: rest => loop(rest, compile(last, next))
 
     private def compileStar(inner: Regex, next: Int): Int =
       val splitPc = reserve()

--- a/regex/Regex.scala
+++ b/regex/Regex.scala
@@ -209,6 +209,18 @@ enum Regex:
    * [[Star]] bodies (loop iterations past the first can never be at position 0 again). Guards
    * `Subset.derive`'s post-derivation strip pass so it's a single cheap check - not a tree
    * walk - for the overwhelming majority of patterns that never use `^`/`\A` at all.
+   *
+   * Deliberately plain structural recursion through each child's own `.hasStartAnchor` (not a
+   * worklist loop): `Subset.stripStartAnchor` re-checks this at every level of its own descent,
+   * relying on it being O(1) once the top-level check has run - which only holds if reaching a
+   * child here forces (and permanently caches, via that child's own `lazy val`) that child's
+   * result too. A worklist loop computing the boolean inline, without ever touching each
+   * child's own `hasStartAnchor`, would lose exactly that cross-node memoization and turn
+   * `stripStartAnchor`'s per-level "cheap check" into a fresh sub-tree walk at every level -
+   * same trade `nullable`/`alphabetBoundaries` above already decline for the same reason, and
+   * (like them) can't use `deepRecursive` either: a `lazy val`'s self-references are bare
+   * `Select`s, not `Apply` nodes, so the macro has nothing to trampoline. Shares their same
+   * pre-existing, accepted stack-depth ceiling as a result.
    */
   @threadUnsafe lazy val hasStartAnchor: Boolean = this match
     case StartAnchor => true

--- a/regex/Subset.scala
+++ b/regex/Subset.scala
@@ -67,24 +67,13 @@ object Subset:
     r match
       case Eps | Empty | Chars(_) | StartAnchor => r
       case Concat(a, b) => eraseGroups(a).concat(eraseGroups(b))
-      case Alt(parts) => Regex.alt(eraseGroupsAll(parts.toList, Nil))
-      case Inter(parts) => Regex.inter(eraseGroupsAll(parts.toList, Nil))
+      case Alt(parts) => Regex.alt(parts.toList.map(eraseGroups))
+      case Inter(parts) => Regex.inter(parts.map(eraseGroups))
       case Star(inner) => eraseGroups(inner).star
       case Repeat(inner, lo, hi) => eraseGroups(inner).repeat(lo, hi)
       case Compl(inner) => !eraseGroups(inner)
       case Look(inner, positive) => Regex.lookahead(eraseGroups(inner), positive)
       case Group(_, _, inner) => eraseGroups(inner)
-
-  /**
-   * Like [[deriveAll]]/[[deriveAllConcat]]: a plain `@tailrec` loop over `parts` rather than
-   * `parts.map(eraseGroups)`, since a self-call inside the closure `.map` passes wouldn't be
-   * something `deepRecursive` can trampoline (see its own docs) - each part instead re-enters
-   * `eraseGroups` as a fresh top-level call.
-   */
-  @tailrec
-  private def eraseGroupsAll(parts: List[Regex], acc: List[Regex]): List[Regex] = parts match
-    case Nil => acc
-    case head :: tail => eraseGroupsAll(tail, eraseGroups(head) :: acc)
 
   /** Parses a pattern into a [[Subset]]. */
   def parse(pattern: String): Either[RegexParseError, Subset] = RegexParser.parse(pattern).map(of)
@@ -179,7 +168,7 @@ object Subset:
          */
         case Concat(Look(r, positive), b) =>
           val bc = b.derive(c)
-          if positive then if r.nullable then bc else bc & (r.derive(c).concat(Regex.all))
+          if positive then if r.nullable then bc else bc & r.derive(c).concat(Regex.all)
           else if r.nullable then Empty
           else bc & !r.derive(c).concat(Regex.all)
 
@@ -197,13 +186,13 @@ object Subset:
          * majority) on the cheaper generic path below, sharing `b` instead of duplicating it.
          */
         case Concat(Alt(parts), b) if parts.exists(hasLeadingLook) =>
-          Regex.alt(deriveAllConcat(parts.toList, b, c, Nil))
+          Regex.alt(parts.toVector.map(_.concat(b).derive(c)))
         case Concat(a, b) =>
           val acb = a.derive(c).concat(b)
           if a.nullable then acb | b.derive(c)
           else acb
-        case Alt(parts) => Regex.alt(deriveAll(parts.toList, c, Nil))
-        case Inter(parts) => Regex.inter(deriveAll(parts.toList, c, Nil))
+        case Alt(parts) => Regex.alt(parts.toVector.map(_.derive(c)))
+        case Inter(parts) => Regex.inter(parts.map(_.derive(c)))
         case s @ Star(inner) => inner.derive(c).concat(s)
 
         /**
@@ -225,37 +214,6 @@ object Subset:
 
         /** Never reached: [[Subset.of]] erases every `Group` before anything reaches here. */
         case g: Group => throw MatchError(s"unreachable: Subset never sees Group nodes (erased by Subset.of): $g")
-
-  /**
-   * Plain `@tailrec` loops, not `TailRec`-trampolined: unlike `deriveImpl`'s tree recursion
-   * (whose depth tracks regex structure and needs the heap-based trampoline for stack
-   * safety), these only walk a flat list — `parts`/`reps` — whose length is bounded by
-   * branch/partition count, not tree depth. Composing them through `tailcall`/`for` would
-   * still be stack-safe but pays for a `Cont` continuation-object allocation per list
-   * element; forcing each `deriveImpl(...).result` eagerly here avoids that allocation.
-   *
-   * Trade-off: each forced `.result` is a real (non-tail) JVM call into `deriveImpl`, so an
-   * `Alt`/`Inter` node nested inside another `Alt`/`Inter`'s part now grows the JVM call
-   * stack by one frame per nesting level, instead of being folded into the single top-level
-   * trampoline as before. Verified this stays within the JVM's minimum stack size
-   * (`-Xss208k`) for the worst case the library's own `maxRepeatBound` allows (one `{0,1000}`
-   * quantifier); deliberately-adversarial nesting far beyond that bound can still overflow —
-   * same pre-existing ceiling `Regex#hashCode`/`nullable`/`alphabetBoundaries` already have,
-   * since those are also plain structural recursion, not trampolined.
-   */
-  @tailrec
-  private def deriveAll(parts: List[Regex], c: Int, acc: List[Regex]): List[Regex] = parts match
-    case Nil => acc
-    case head :: tail => deriveAll(tail, c, head.derive(c) :: acc)
-
-  /**
-   * Like [[deriveAll]], but concatenates each part with `b` before deriving - see the
-   * `Concat(Alt(parts), b)` case above.
-   */
-  @tailrec
-  private def deriveAllConcat(parts: List[Regex], b: Regex, c: Int, acc: List[Regex]): List[Regex] = parts match
-    case Nil => acc
-    case head :: tail => deriveAllConcat(tail, b, c, head.concat(b).derive(c) :: acc)
 
   /**
    * `reps` is `Array[Int]`, not `List[Int]`: `List[Int]` boxes every element as a
@@ -292,22 +250,24 @@ object Subset:
    * one node deriving it, but `^`/`\A` has to die *globally*, in parts of the tree the current
    * derivative step never visits at all — a single recursive sweep over the whole result is the
    * simplest way to guarantee that. `hasStartAnchor` keeps this a single cheap check (not a tree
-   * walk) for the overwhelming majority of patterns that never use `^`/`\A`.
+   * walk) for the overwhelming majority of patterns that never use `^`/`\A` - so only a pattern
+   * that actually contains one ever pays for the `deepRecursive` trampoline below.
    */
   private def stripStartAnchor(r: Regex): Regex =
     if !r.hasStartAnchor then r
     else
-      r match
-        case StartAnchor => Empty
-        case Concat(a, b) => stripStartAnchor(a).concat(stripStartAnchor(b))
-        case Alt(parts) => Regex.alt(parts.map(stripStartAnchor))
-        case Inter(parts) => Regex.inter(parts.map(stripStartAnchor))
-        case Star(inner) => stripStartAnchor(inner).star
-        case Repeat(inner, lo, hi) => stripStartAnchor(inner).repeat(lo, hi)
-        case Compl(inner) => !stripStartAnchor(inner)
-        case Look(inner, positive) => Regex.lookahead(stripStartAnchor(inner), positive)
-        case g: Group => throw MatchError(s"unreachable: Subset never sees Group nodes (erased by Subset.of): $g")
-        case _ => r
+      deepRecursive:
+        r match
+          case StartAnchor => Empty
+          case Concat(a, b) => stripStartAnchor(a).concat(stripStartAnchor(b))
+          case Alt(parts) => Regex.alt(parts.toVector.map(stripStartAnchor))
+          case Inter(parts) => Regex.inter(parts.map(stripStartAnchor))
+          case Star(inner) => stripStartAnchor(inner).star
+          case Repeat(inner, lo, hi) => stripStartAnchor(inner).repeat(lo, hi)
+          case Compl(inner) => !stripStartAnchor(inner)
+          case Look(inner, positive) => Regex.lookahead(stripStartAnchor(inner), positive)
+          case g: Group => throw MatchError(s"unreachable: Subset never sees Group nodes (erased by Subset.of): $g")
+          case _ => r
 
   /**
    * Returns one representative code point per equivalence class of the alphabet


### PR DESCRIPTION
Stacked on #74 (commons 0.1.2) - this needs `TailRecTraversable`, which
doesn't exist in 0.1.1. Retarget to `main` once #74 merges.

## What

commons 0.1.2 added `TailRecTraversable`, letting `deepRecursive` trampoline
a self-call inside a `.map(...)` closure over `List`/`Vector`/`Set`/`Option`/
`Either` - not just a bare top-level self-call. Uses that to drop three
hand-written `@tailrec` accumulator loops that existed only to work around
the old limitation:

- `Subset.eraseGroupsAll` -> `Alt`/`Inter` now just `parts.toList.map(eraseGroups)`
  / `parts.map(eraseGroups)`.
- `Subset.deriveAll`/`deriveAllConcat` -> folded directly into `rawDerive`'s
  `Alt`/`Inter`/`Concat(Alt(...), b)` cases via `parts.toVector.map(...)`.
  `.toVector` instead of `.toList`: `AltBranches` already stores a `Vector`,
  so this is a free field read instead of an extra copy - benchmarked
  (`SubsetBenchmark.isEmptyCheckManyStates`) on par with or better than the
  `@tailrec`-loop-over-`.toList` version it replaces.

`Subset.stripStartAnchor` gets the same `deepRecursive` treatment - it was
plain, entirely unprotected recursion before this (verified: a 200k-deep
chain with a buried `^` overflows a 208k-stack JVM without this, survives at
300k-deep with it). `Regex.hasStartAnchor` stays a plain recursive `lazy
val`, deliberately not touched: `stripStartAnchor` re-checks it at every
level of its own descent, relying on each check being O(1) via the child's
own cached `lazy val` - a worklist-loop rewrite (tried, reverted) would drop
that cross-node memoization and turn every level into a fresh sub-tree walk
instead.

`Capture.scala` gets two of its own fixes, found doing the same sweep:
`CaptureMatcher.collectNames` (plain recursion, no protection at all before
this) and `NfaCompiler.compileAlt` (unbounded `Alt` branch count, not tree
depth) both had real, verified overflows. Both use a plain `@tailrec` loop
instead of `deepRecursive`: `collectNames` because it's flat `Map`
accumulation (same shape as the existing `numGroups` right next to it),
`compileAlt` because reversing the branch list and folding `Split`s backward
rebuilds the exact same nested-`Split` structure the natural recursion
would, with no per-branch trampoline dispatch cost - measured
indistinguishable from the pre-existing baseline, where the `deepRecursive`
version measured a real ~10% regression on
`CaptureBenchmark.compileEmailPattern`.

Two more overflow-prone spots were found but are out of scope here:
`RegexParser`'s `parseAlt`/`parseConcat`/.../`parseGroup` recursive-descent
mutual recursion (`deepRecursive` only trampolines a single self-recursive
`def`, not a cycle across many), and `NfaCompiler.compile`'s own `Concat`
case (`compile(a, compile(b, next))` - a self-call nested inside another
self-call's argument, a shape `deepRecursive` silently does not trampoline,
verified the same way). Both would need a bigger rewrite (explicit-stack
state machine) to fix properly.

## Verification

- `--power compile` / `--power test` / `--power fmt --check` all clean.
- Each fixed overflow reproduced (baseline `StackOverflowError` on a deep
  adversarial input at `-J-Xss208k`) and confirmed fixed on the same input,
  not just "compiles" - `deepRecursive` silently no-ops for shapes it can't
  trampoline (a lazy val's bare self-reference, a self-call nested in
  another self-call's argument), so a clean compile alone isn't proof.
- `SubsetBenchmark`/`CaptureBenchmark` re-run before/after each change that
  touches a hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)