### PR TITLE
docs.yaml: unify footer to "made with ❤️ and coffee"

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -36,7 +36,7 @@ jobs:
           scala-cli --power doc . --exclude "bench/**" -- \
           -project "regex" \
           -project-version ${{ github.ref_name }} \
-          -project-footer "halotukozak/regex" \
+          -project-footer "made with ❤️ and coffee" \
           -social-links:github::https://github.com/halotukozak/regex \
           -snippet-compiler:compile \
           -source-links:"src=github://halotukozak/regex?tag=${{ github.ref_name }}" \


### PR DESCRIPTION
Matches commons/made/mcodec/mrpc/alpaca. Kept as a one-off edit (not synced) since regex's `docs.yaml` needs its own `--exclude "bench/**"` for JMH benchmarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)