### PR TITLE
Split ci.yml into shared tests.yml + standalone benchmark.yml

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,62 +1,20 @@
-name: Test
+name: Benchmark
 
 on:
   pull_request:
-  push:
-    branches: [ main ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
+# JMH suite in bench/ against the PR branch and against main, back-to-back on
+# the same runner, then diffed. Informational only — a shared runner is too
+# noisy to gate merges on, so this is a separate workflow from the shared
+# `test` job and never required.
 jobs:
-  test:
-    permissions:
-      contents: read
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-      - name: Set up JDK
-        uses: actions/setup-java@v6
-        with:
-          java-version: 21
-          distribution: 'temurin'
-      - name: Cache Mill dependencies
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cache/coursier
-            ~/.cache/mill
-          key: ${{ runner.os }}-mill-${{ hashFiles('build.mill') }}
-          restore-keys: |
-            ${{ runner.os }}-mill-
-
-      - name: Compile
-        run: ./mill __.compile
-      - name: Compile tests
-        run: ./mill __.test.compile
-      - name: Run tests
-        run: ./mill __.test
-      - name: Code coverage
-        run: ./mill jvm.scoverage.xmlCoberturaReport
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          slug: halotukozak-com/regex
-          fail_ci_if_error: false
-      - name: Scalafmt
-        run: ./mill mill.scalalib.scalafmt/checkFormatAll
-      - name: Generate docs
-        run: ./mill jvm.docJar
-
-  # JMH suite in bench/ against the PR branch and against main, back-to-back on
-  # the same runner, then diffed. Informational only — a shared runner is too
-  # noisy to gate merges on.
   benchmark:
     name: Benchmark (current vs main)
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,52 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+# Shared CI for the Mill-built libraries (regex, alpaca). Platform-agnostic
+# `./mill __.*` selectors, so the one file works whether or not a repo has a
+# Scala.js module. Job name `test` matches both repos' branch protection.
+jobs:
+  test:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+      - name: Set up JDK
+        uses: actions/setup-java@v6
+        with:
+          java-version: 21
+          distribution: 'temurin'
+      - name: Cache Mill dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cache/coursier
+            ~/.cache/mill
+          key: ${{ runner.os }}-mill-${{ hashFiles('build.mill') }}
+          restore-keys: |
+            ${{ runner.os }}-mill-
+
+      - name: Compile
+        run: ./mill __.compile
+      - name: Compile tests
+        run: ./mill __.test.compile
+      - name: Run tests
+        run: ./mill __.test
+      - name: Code coverage
+        run: ./mill jvm.scoverage.xmlCoberturaReport
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: halotukozak-com/${{ github.event.repository.name }}
+          fail_ci_if_error: false
+      - name: Scalafmt
+        run: ./mill mill.scalalib.scalafmt/checkFormatAll
+      - name: Generate docs
+        run: ./mill jvm.docJar

--- a/bench/README.md
+++ b/bench/README.md
@@ -5,23 +5,22 @@ JMH microbenchmarks for the hot paths of this library: `Regex` construction (`al
 machinery in `Subset` (`subset`/`isEmpty`/`derive`), `CharSet.contains`, and the compiled
 `TokenMatcher` DFA (`matchAt`/`findFirst`/`compile`).
 
-This directory only compiles under `--jmh` — it's excluded (`--exclude "bench/**"`) from every
-other `scala-cli` invocation (`compile`, `test`, `doc`, `publish`) because `@Benchmark` needs
-`jmh-core` on the classpath, which `--jmh` injects automatically.
+Its own Mill module (`bench`), a `JmhModule` depending on `jvm` — never compiled into, tested
+with, or published as part of the library.
 
 ## Running locally
 
 ```sh
 # everything
-scala-cli run --jmh . --exclude "test/**"
+./mill bench.runJmh '.*'
 
 # one class, faster iteration while developing a benchmark
-scala-cli run --jmh . --exclude "test/**" -- SubsetBenchmark -f 1 -wi 2 -i 2 -w 300ms -r 300ms
+./mill bench.runJmh 'SubsetBenchmark' -f 1 -wi 2 -i 2 -w 300ms -r 300ms
 ```
 
 ## CI
 
-On every PR, the `benchmark` job in `.github/workflows/ci.yml` runs this suite against the PR
-branch and against `main` (same `bench/` harness both times, via a `git worktree`, so only
-`regex/` differs) and posts a comparison table to the job summary. It's informational only — a
+On every PR, `.github/workflows/benchmark.yml` runs this suite against the PR branch and against
+`main` (same `bench/` harness both times, via a `git worktree`, so only `src/` differs) and
+posts a comparison table to the job summary and as a PR comment. It's informational only — a
 shared GitHub-hosted runner is too noisy for single-sample numbers to gate a merge on.


### PR DESCRIPTION
## Summary

Companion to [halotukozak-com/.github#12](https://github.com/halotukozak-com/.github/pull/12) (shared Mill CI).

- `.github/workflows/tests.yml` — verbatim copy of `.github`'s new `shared/ci-mill.yml`. Landed directly here (not waiting on the sync bot) so there's never a window without a `test` check, given branch protection requires it.
- `.github/workflows/benchmark.yml` — the JMH comparison job, lifted out of `ci.yml` unchanged. PR-only, never required (it was already `if: github.event_name == 'pull_request'`).
- `ci.yml` deleted (git shows it as a rename to `benchmark.yml`).
- `bench/README.md` refreshed — it still described the scala-cli `--jmh` workflow the Mill migration replaced.

Once `.github#12` merges, the sync bot's `tests.yml` PR here will be a no-op (file already matches).

## Test plan

- [ ] `test` job green (same as the old `ci.yml` `test` job — identical steps)
- [ ] `Benchmark (current vs main)` green and comments the JMH delta
- [ ] No duplicate `test` check from a leftover workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)