### PR TITLE
Remove dead .scoverage/report.sc gitignore exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,7 @@ build/
 .bsp/
 .scala-build/
 .scala-doc/
-.scoverage/*
-!.scoverage/report.sc
+.scoverage/
 scala-doc
 .metals/
 


### PR DESCRIPTION
Leftover from the scala-cli build (Mill's ScoverageModule replaced `.scoverage/report.sc`, which no longer exists in this repo).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>