### PR TITLE
Patch scaladoc's jQuery-dependent same-page navigation in docs deploy

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -43,6 +43,21 @@ jobs:
             ${{ runner.os }}-mill-
       - name: Generate documentation
         run: ./mill jvm.docJar
+
+      # Scala 3.9.x's bundled scaladoc emits a ux.js that still calls jQuery's
+      # `$.get` for SPA-style same-page navigation (sidebar/TOC link clicks) but
+      # no longer loads jQuery, so every in-page link click throws
+      # "ReferenceError: $ is not defined" right after the handler has already
+      # called preventDefault(), and navigation silently breaks on the deployed
+      # site. Fixed upstream in scala/scala3#26664 + scala/scala3#22014 (first
+      # released in 3.10.0-RC1). Until this repo builds on scaladoc >= 3.10.0,
+      # swap the jQuery call for an equivalent native fetch(); the sed is a
+      # no-op once the generated ux.js no longer contains the pattern.
+      - name: Patch scaladoc jQuery navigation bug
+        run: |
+          sed -i 's/\$\.get(href, function (data) {/fetch(href).then((r) => r.text()).then(function (data) {/' \
+            out/jvm/docJar.dest/docs/scripts/ux.js
+
       - name: Inject Umami analytics
         run: |
           find out/jvm/docJar.dest/docs -name '*.html' -exec sed -i \


### PR DESCRIPTION
## Summary
- This repo builds docs with Scala **3.9.0**. Scaladoc's bundled `scripts/ux.js` still calls jQuery's `$.get` for SPA-style same-page navigation (sidebar/TOC link clicks), but scaladoc no longer loads jQuery.
- Every in-page link click throws `ReferenceError: $ is not defined` right after the handler has already called `preventDefault()`, so navigation silently breaks on the deployed docs site (https://halotukozak-com.github.io/regex/).
- Patches the generated `ux.js` in `docs.yaml` right after `./mill jvm.docJar`, swapping the jQuery call for an equivalent native `fetch()`.

## Upstream
Fixed in scala/scala3#26664 ("Scaladoc: Stop hijacking link clicks", removes the `$.get` block) + scala/scala3#22014 (removes the remaining `$(...)` calls). Both first released in **3.10.0-RC1** (2026-08-27); neither is in 3.9.0 or any 3.9.0-RC, and the `lts-3.9` branch is still broken.

Once this repo builds on scaladoc >= 3.10.0, this step can be dropped. It is safe to leave in across the bump — the `sed` is a no-op once the generated `ux.js` no longer contains the pattern.

## Test plan
- [x] `sed` pattern matches the exact line in the currently deployed `ux.js` (`$.get(href, function (data) {` at `scripts/ux.js:180`).
- [x] Same patch verified in halotukozak-com/alpaca#541.
- [ ] After merge + deploy, click through sidebar/tab navigation on the live docs site with the console open — no `ReferenceError`, navigation works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)