### PR TITLE
Enable -Xcheck-macros

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -29,6 +29,7 @@ object `package` extends Module:
       "-language:noAutoTupling",
       "-Vprofile",
       "-Xprint-inline",
+      "-Xcheck-macros",
       "-Ycheck:macros",
       "-Ydebug-flags",
       "-Ydebug-missing-refs",


### PR DESCRIPTION
## Summary
- Enables `-Xcheck-macros` (alongside the existing `-Ycheck:macros`) in `build.mill`, re-typechecking macro-expanded trees against the compiler's tree invariants to catch macro correctness bugs invisible without it.
- No code changes were needed — the macro code here was already tree-clean.

## Test plan
- [x] `./mill __.compile` — clean, all modules (jvm/js/native/bench/scripts)
- [x] `./mill jvm.test` — 185/185 green
- [x] `./mill js.test` — 159/159 green
- [x] `./mill native.test` — 181/181 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)